### PR TITLE
Shared Mixins to enable effortless Studio-editable XBlocks (OC-513)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.log
 *.pyc
 .coverage
+cover
 xblock_utils.egg-info
 tests.integration.*.png

--- a/README.rst
+++ b/README.rst
@@ -67,9 +67,11 @@ Supported field types:
   ``field_name = String(multiline_editor=True, resettable_editor=False)``
 * String (html):
   ``field_name = String(multiline_editor='html', resettable_editor=False)``
-* Any of the above will use a dropdown menu if they have a pre-defined
-  list of possible values.
-* List of undordered unique values (i.e. sets) drawn from a small set of
+
+Any of the above will use a dropdown menu if they have a pre-defined
+list of possible values.
+
+* List of unordered unique values (i.e. sets) drawn from a small set of
   possible values:
   ``field_name = List(list_style='set', list_values_provider=some_method)``
 
@@ -78,9 +80,9 @@ Supported field types:
   - The ``List`` declaration must also define a ``list_values_provider`` method
     which will be called with the block as its only parameter and which must
     return a list of possible values.
-* Rudimentary support for List, Dict, and any other JSONField-derived field types
+* Rudimentary support for Dict, ordered List, and any other JSONField-derived field types
 
-  - ``list_field = List(display_name="Normal List", default=[])``
+  - ``list_field = List(display_name="Ordered List", default=[])``
   - ``dict_field = Dict(display_name="Normal Dict", default={})``
 
 Supported field options (all field types):
@@ -117,14 +119,14 @@ StudioContainerXBlockMixin
 
     from xblockutils.studio_editable import StudioContainerXBlockMixin
 
-This mixin helps with creating XBlocks that want to allow content
-authors to add/remove/reorder child blocks. By removing any existing
+This mixin helps to create XBlocks that allow content authors to add,
+remove, or reorder child blocks. By removing any existing
 ``author_view`` and adding this mixin, you'll get editable,
-re-orderable, deletable child support in Studio. To enable authors to
-add new children, simply override ``author_edit_view`` and set
-``can_add=True`` when calling ``render_children`` - see the source code.
-To enable authors to add only a limited subset of children requires
-custom HTML.
+re-orderable, and deletable child support in Studio. To enable authors to
+add arbitrary blocks as children, simply override ``author_edit_view`` 
+and set ``can_add=True`` when calling ``render_children`` - see the 
+source code. To restrict authors so they can add only specific types of
+child blocks or a limited number of children requires custom HTML.
 
 An example is the mentoring XBlock: |Screenshot 2|
 
@@ -177,9 +179,17 @@ child\_isinstance
 
 If your XBlock needs to find children/descendants of a particular
 class/mixin, you should use
-``child_isinstance(self, child_usage_id, SomeXBlockClassOrMixin)``
+
+.. code:: python
+
+    child_isinstance(self, child_usage_id, SomeXBlockClassOrMixin)
+
 rather than calling
-``isinstance(self.runtime.get_block(child_usage_id), SomeXBlockClassOrMixin)``.
+
+.. code:: python
+
+    ``isinstance(self.runtime.get_block(child_usage_id), SomeXBlockClassOrMixin)``.
+
 On runtimes such as those in edx-platform, ``child_isinstance`` is
 orders of magnitude faster.
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 xblock-utils: Various utilities for XBlocks
--------------------------------------------
+===========================================
 
 These are a collection of useful utility functions,
 test base classes and documentation shared by many XBlocks.
@@ -10,4 +10,166 @@ test base classes and documentation shared by many XBlocks.
 
 To test the utilities, run::
 
-    ./run_tests.py
+    python run_tests.py
+
+To get a coverage report, use:
+
+    python run_tests.py --with-coverage --cover-package=xblockutils
+
+
+StudioEditableXBlockMixin
+-------------------------
+
+.. code:: python
+
+    from xblockutils.studio_editable import StudioEditableXBlockMixin
+
+This mixin will automatically generate a working ``studio_view`` form
+that allows content authors to edit the fields of your XBlock. To use,
+simply add the class to your base class list, and add a new class field
+called ``editable_fields``, set to a tuple of the names of the fields
+you want your user to be able to edit.
+
+.. code:: python
+
+    @XBlock.needs("i18n")
+    class ExampleBlock(StudioEditableXBlockMixin, XBlock):
+        ...
+        mode = String(
+            display_name="Mode",
+            help="Determines the behaviour of this component. Standard is recommended.",
+            default='standard',
+            scope=Scope.content,
+            values=('standard', 'crazy')
+        )
+        editable_fields = ('mode', 'display_name')
+
+That's all you need to do. The mixin will read the optional
+``display_name``, ``help``, ``default``, and ``values`` settings from
+the fields you mention and build the editor form as well as an AJAX save
+handler.
+
+If you want to validate the data, you can override
+``validate_field_data(self, validation, data)`` and/or
+``clean_studio_edits(self, data)`` - see the source code for details.
+
+Supported field types:
+
+* Boolean:
+  ``field_name = Boolean(display_name="Field Name")``
+* Float:
+  ``field_name = Float(display_name="Field Name")`` 
+* Integer:
+  ``field_name = Integer(display_name="Field Name")`` 
+* String:
+  ``field_name = String(display_name="Field Name")`` 
+* String (multiline):
+  ``field_name = String(multiline_editor=True, resettable_editor=False)``
+* String (html):
+  ``field_name = String(multiline_editor='html', resettable_editor=False)``
+* Any of the above will use a dropdown menu if they have a pre-defined
+  list of possible values.
+* Rudimentary support for List, Dict, and any other JSONField-derived field types
+
+  - ``list_field = List(display_name="Normal List", default=[])``
+  - ``dict_field = Dict(display_name="Normal Dict", default={})``
+
+Supported field options (all field types):
+
+* ``values`` can define a list of possible options, changing the UI element
+  to a select box. Values can be set to any of the formats `defined in the
+  XBlock source code <https://github.com/edx/XBlock/blob/master/xblock/fields.py>`__:
+  
+  - A finite set of elements: ``[1, 2, 3]``
+  - A finite set of elements where the display names differ from the values
+    ::
+        [
+            {"display_name": "Always", "value": "always"},
+            {"display_name": "Past Due", "value": "past_due"},
+        ]
+  - A range for floating point numbers with specific increments:
+    ``{"min": 0 , "max": 10, "step": .1}``
+  - A callable that returns one of the above. (Note: the callable does
+    *not* get passed the XBlock instance or runtime, so it cannot be a
+    normal member function)
+* ``resettable_editor`` - defaults to ``True``. Set ``False`` to hide the
+  "Reset" button used to return a field to its default value by removing
+  the field's value from the XBlock instance.
+
+Basic screenshot: |Screenshot 1|
+
+StudioContainerXBlockMixin
+--------------------------
+
+.. code:: python
+
+    from xblockutils.studio_editable import StudioContainerXBlockMixin
+
+This mixin helps with creating XBlocks that want to allow content
+authors to add/remove/reorder child blocks. By removing any existing
+``author_view`` and adding this mixin, you'll get editable,
+re-orderable, deletable child support in Studio. To enable authors to
+add new children, simply override ``author_edit_view`` and set
+``can_add=True`` when calling ``render_children`` - see the source code.
+To enable authors to add only a limited subset of children requires
+custom HTML.
+
+An example is the mentoring XBlock: |Screenshot 2|
+
+SeleniumXBlockTest
+------------------
+
+.. code:: python
+
+    from xblockutils.base_test import SeleniumXBlockTest
+
+This is a base class that you can use for writing Selenium integration
+tests that are hosted in the XBlock SDK (Workbench).
+
+Here is an example:
+
+.. code:: python
+
+    class TestStudentView(SeleniumXBlockTest):
+        """
+        Test the Student View of MyCoolXBlock
+        """
+        def setUp(self):
+            super(TestStudentView, self).setUp()
+            self.set_scenario_xml('<mycoolblock display_name="Test Demo Block" field2="hello" />')
+            self.element = self.go_to_view("student_view")
+
+        def test_shows_field_2(self):
+            """
+            The xblock should display the text value of field2.
+            """
+            self.assertIn("hello", self.element.text)
+
+StudioEditableBaseTest
+----------------------
+
+.. code:: python
+
+    from xblockutils.studio_editable_test import StudioEditableBaseTest
+
+This is a subclass of ``SeleniumXBlockTest`` that adds a few helper
+methods useful for testing the ``studio_view`` of any XBlock using
+``StudioEditableXBlockMixin``.
+
+child\_isinstance
+-----------------
+
+.. code:: python
+
+    from xblockutils.helpers import child_isinstance
+
+If your XBlock needs to find children/descendants of a particular
+class/mixin, you should use
+``child_isinstance(self, child_usage_id, SomeXBlockClassOrMixin)``
+rather than calling
+``isinstance(self.runtime.get_block(child_usage_id), SomeXBlockClassOrMixin)``.
+On runtimes such as those in edx-platform, ``child_isinstance`` is
+orders of magnitude faster.
+
+.. |Screenshot 1| image:: https://cloud.githubusercontent.com/assets/945577/6341782/7d237966-bb83-11e4-9344-faa647056999.png
+.. |Screenshot 2| image:: https://cloud.githubusercontent.com/assets/945577/6341803/d0195ec4-bb83-11e4-82f6-8052c9f70690.png

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ To test the utilities, run::
 
 To get a coverage report, use:
 
-    python run_tests.py --with-coverage --cover-package=xblockutils
+    python run_tests.py --with-coverage --cover-package=xblockutils --cover-html
 
 
 StudioEditableXBlockMixin

--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,9 @@ Supported field options (all field types):
   - A callable that returns one of the above. (Note: the callable does
     *not* get passed the XBlock instance or runtime, so it cannot be a
     normal member function)
+* ``values_provider`` can define a callable that accepts the XBlock
+  instance as an argument, and returns a list of possible values in one
+  of the formats listed above.
 * ``resettable_editor`` - defaults to ``True``. Set ``False`` to hide the
   "Reset" button used to return a field to its default value by removing
   the field's value from the XBlock instance.

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,15 @@ Supported field types:
   ``field_name = String(multiline_editor='html', resettable_editor=False)``
 * Any of the above will use a dropdown menu if they have a pre-defined
   list of possible values.
+* List of undordered unique values (i.e. sets) drawn from a small set of
+  possible values:
+  ``field_name = List(list_style='set', list_values_provider=some_method)``
+
+  - The ``List`` declaration must include the property ``list_style='set'`` to
+    indicate that the ``List`` field is being used with set semantics.
+  - The ``List`` declaration must also define a ``list_values_provider`` method
+    which will be called with the block as its only parameter and which must
+    return a list of possible values.
 * Rudimentary support for List, Dict, and any other JSONField-derived field types
 
   - ``list_field = List(display_name="Normal List", default=[])``

--- a/pylintrc
+++ b/pylintrc
@@ -15,10 +15,12 @@ disable=
 	protected-access,
 	star-args,
 	too-few-public-methods,
-	too-many-public-methods,
 	too-many-ancestors,
 	too-many-arguments,
+	too-many-branches,
 	too-many-locals,
+	too-many-public-methods,
+	too-many-statements,
 	unused-argument
 
 [SIMILARITIES]

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,17 @@ import os
 import os.path
 from setuptools import setup
 
+
+def package_data(pkg, root_list):
+    """Generic function to find package_data for `pkg` under `root`."""
+    data = []
+    for root in root_list:
+        for dirname, _, files in os.walk(os.path.join(pkg, root)):
+            for fname in files:
+                data.append(os.path.relpath(os.path.join(dirname, fname), pkg))
+
+    return {pkg: data}
+
 setup(
     name='xblock-utils',
     version='0.1a0',
@@ -31,5 +42,6 @@ setup(
     ],
     install_requires=[
         'XBlock',
-    ]
+    ],
+    package_data=package_data("xblockutils", ["public", "templates"]),
 )

--- a/tests/integration/test_studio_editable.py
+++ b/tests/integration/test_studio_editable.py
@@ -1,0 +1,276 @@
+from xblock.core import XBlock
+from xblock.fields import Boolean, Dict, Float, Integer, List, String
+from xblock.validation import ValidationMessage
+from xblockutils.studio_editable import StudioEditableXBlockMixin
+from xblockutils.studio_editable_test import StudioEditableBaseTest
+
+
+class EditableXBlock(StudioEditableXBlockMixin, XBlock):
+    """
+    A Studio-editable XBlock
+    """
+    color = String(default="red")
+    count = Integer(default=42)
+    comment = String(default="")
+    editable_fields = ('color', 'count', 'comment')
+
+    def validate_field_data(self, validation, data):
+        """ Basic validation method for these tests """
+        if data.count <=0:
+            validation.add(ValidationMessage(ValidationMessage.ERROR, u"Count cannot be negative"))
+        if "damn" in data.comment.lower():
+            validation.add(ValidationMessage(ValidationMessage.ERROR, u"No swearing allowed"))
+
+
+class TestEditableXBlock_StudioView(StudioEditableBaseTest):
+    """
+    Test the Studio View created for EditableXBlock
+    """
+    @XBlock.register_temp_plugin(EditableXBlock, "editable")
+    def setUp(self):
+        super(TestEditableXBlock_StudioView, self).setUp()
+        self.set_scenario_xml('<editable />')
+        self.go_to_view("studio_view")
+        self.fix_js_environment()
+
+    def test_no_changes_with_defaults(self):
+        """
+        If we load the edit form and then save right away, there should be no changes.
+        """
+        block = self.load_root_xblock()
+        orig_values = {field_name: getattr(block, field_name) for field_name in EditableXBlock.editable_fields}
+        self.click_save()
+        for field_name in EditableXBlock.editable_fields:
+            self.assertEqual(getattr(block, field_name), orig_values[field_name])
+            self.assertFalse(block.fields[field_name].is_set_on(block))
+
+    def test_no_changes_with_values_set(self):
+        """
+        If the XBlock already has explicit values set, and we load the edit form and then save
+        right away, there should be no changes.
+        """
+        block = self.load_root_xblock()
+        block.color = "green"
+        block.count = 5
+        block.comment = "Hello"
+        block.save()
+        orig_values = {field_name: getattr(block, field_name) for field_name in EditableXBlock.editable_fields}
+        # Reload the page:
+        self.go_to_view("studio_view")
+        self.fix_js_environment()
+
+        self.click_save()
+        block = self.load_root_xblock()  # Need to reload the block to bypass its cache
+        for field_name in EditableXBlock.editable_fields:
+            self.assertEqual(getattr(block, field_name), orig_values[field_name])
+            self.assertTrue(block.fields[field_name].is_set_on(block))
+
+    def test_explicit_overrides(self):
+        """
+        Test that we can override the defaults with the same value as the default, and that the
+        value will be saved explicitly.
+        """
+        block = self.load_root_xblock()
+        for field_name in EditableXBlock.editable_fields:
+            self.assertFalse(block.fields[field_name].is_set_on(block))
+
+        color_control = self.get_element_for_field('color')
+        color_control.clear()
+        color_control.send_keys('red')
+
+        count_control = self.get_element_for_field('count')
+        count_control.clear()
+        count_control.send_keys('42')
+
+        comment_control = self.get_element_for_field('comment')
+        comment_control.send_keys('forcing a change')
+        comment_control.clear()
+
+        self.click_save()
+        for field_name in EditableXBlock.editable_fields:
+            self.assertEqual(getattr(block, field_name), block.fields[field_name].default)
+            self.assertTrue(block.fields[field_name].is_set_on(block))
+
+    def test_set_and_reset(self):
+        """
+        Test that we can set values, save, then reset to defaults.
+        """
+        block = self.load_root_xblock()
+        for field_name in EditableXBlock.editable_fields:
+            self.assertFalse(block.fields[field_name].is_set_on(block))
+
+        for field_name in EditableXBlock.editable_fields:
+            color_control = self.get_element_for_field(field_name)
+            color_control.clear()
+            color_control.send_keys('1000')
+
+        self.click_save()
+
+        self.assertEqual(block.color, '1000')
+        self.assertEqual(block.count, 1000)
+        self.assertEqual(block.comment, '1000')
+
+        for field_name in EditableXBlock.editable_fields:
+            self.click_reset_for_field(field_name)
+
+        self.click_save()
+        block = self.load_root_xblock()  # Need to reload the block to bypass its cache
+        for field_name in EditableXBlock.editable_fields:
+            self.assertEqual(getattr(block, field_name), block.fields[field_name].default)
+            self.assertFalse(block.fields[field_name].is_set_on(block))
+
+    def test_invalid_data(self):
+        """
+        Test that we get notified when there's a problem with our data.
+        """
+        def assert_unchanged():
+            block = self.load_root_xblock()
+            for field_name in EditableXBlock.editable_fields:
+                self.assertEqual(getattr(block, field_name), block.fields[field_name].default)
+                self.assertFalse(block.fields[field_name].is_set_on(block))
+        def expect_error_message(expected_message):
+            notification = self.dequeue_runtime_notification()
+            self.assertEqual(notification[0], "error")
+            self.assertEqual(notification[1]["title"], "Unable to update settings")
+            self.assertEqual(notification[1]["message"], expected_message)
+
+        color_control = self.get_element_for_field('color')
+        color_control.clear()
+        color_control.send_keys('orange')
+
+        count_control = self.get_element_for_field('count')
+        count_control.clear()
+        count_control.send_keys('-10')
+
+        comment_control = self.get_element_for_field('comment')
+        comment_control.send_keys("That's a damn shame.")
+
+        self.click_save(expect_success=False)
+        expect_error_message("Count cannot be negative, No swearing allowed")
+        assert_unchanged()
+
+        count_control.clear()
+        count_control.send_keys('10')
+
+        self.click_save(expect_success=False)
+        expect_error_message("No swearing allowed")
+        assert_unchanged()
+
+        comment_control.clear()
+
+        self.click_save()
+
+
+class FancyXBlock(StudioEditableXBlockMixin, XBlock):
+    """
+    A Studio-editable XBlock with lots of fields and fancy features
+    """
+    bool_normal = Boolean(display_name="Normal Boolean Field")
+    dict_normal = Dict(display_name="Normal Dictionary Field", default={})
+    float_normal = Float(display_name="Normal Float Field")
+    float_values = Float(display_name="Float Field With Values", values=(0, 2.718281, 3.14159,), default=0)
+    int_normal = Integer(display_name="Normal Integer Field")
+    int_ranged = Integer(display_name="Ranged Integer Field", min=1, max=9, default=5, step=2)
+    int_dynamic = Integer(
+        display_name="Integer Field With Dynamic Values",
+        default=0,
+        values=lambda: list(range(0, 10, 2))
+    )
+    int_values = Integer(
+        display_name="Integer Field With Named Values",
+        default=0,
+        values=(
+            {"display_name": "Yes", "value": 1},
+            {"display_name": "No", "value": 0},
+            {"display_name": "Maybe So", "value": -1},
+        )
+    )
+    list_normal = List(display_name="Normal List", default=[])
+    list_intdefs = List(display_name="Integer List With Default", default=[1, 2, 3, 4, 5])
+    list_strdefs = List(display_name="String List With Default", default=['1', '2', '3', '4', '5'])
+    
+    string_normal = String(display_name="Normal String Field")
+    string_values = String(display_name="String Field With Values", default="A", values=("A", "B", "C", "D"))
+    string_named = String(
+        display_name="String Field With Named Values",
+        default="AB",
+        values=(
+            {"display_name": "Alberta", "value": "AB"},
+            {"display_name": "British Columbia", "value": "BC"},
+        )
+    )
+    string_dynamic = String(
+        display_name="String Field With Dynamic Values",
+        default="",
+        values=lambda: [""] + [letter for letter in "AEIOU"]
+    )
+    string_multiline = String(display_name="Multiline", multiline_editor=True, allow_reset=False)
+    string_multiline_reset = String(display_name="Multiline", multiline_editor=True)
+    string_html = String(display_name="Multiline", multiline_editor='html', allow_reset=False)
+    # Note: The HTML editor won't work in Workbench because it depends on Studio's TinyMCE
+
+    editable_fields = (
+        'bool_normal', 'dict_normal', 'float_normal', 'float_values', 'int_normal', 'int_ranged', 'int_dynamic',
+        'int_values', 'list_normal', 'list_intdefs', 'list_strdefs', 'string_normal', 'string_values', 'string_named',
+        'string_dynamic', 'string_multiline', 'string_multiline_reset', 'string_html',
+    )
+
+
+class TestFancyXBlock_StudioView(StudioEditableBaseTest):
+    """
+    Test the Studio View created for FancyXBlock
+    """
+    @XBlock.register_temp_plugin(FancyXBlock, "fancy")
+    def setUp(self):
+        super(TestFancyXBlock_StudioView, self).setUp()
+        self.set_scenario_xml("<fancy/>")
+        self.go_to_view("studio_view")
+        self.fix_js_environment()
+
+    def test_no_changes_with_defaults(self):
+        """
+        If we load the edit form and then save right away, there should be no changes.
+        """
+        block = self.load_root_xblock()
+        orig_values = {field_name: getattr(block, field_name) for field_name in FancyXBlock.editable_fields}
+        self.click_save()
+        for field_name in FancyXBlock.editable_fields:
+            self.assertEqual(getattr(block, field_name), orig_values[field_name])
+            self.assertFalse(block.fields[field_name].is_set_on(block))
+
+    def test_no_changes_with_values_set(self):
+        """
+        If the XBlock already has explicit values set, and we load the edit form and then save
+        right away, there should be no changes.
+        """
+        block = self.load_root_xblock()
+        block.bool_normal = True
+        block.dict_normal = {"more": "cowbell"}
+        block.float_normal = 17.0
+        block.float_values = 3.14159
+        block.int_normal = 10
+        block.int_ranged = 7
+        block.int_dynamic = 0
+        block.int_values = -1
+        block.list_normal = []
+        block.list_intdefs = [9, 10, 11]
+        block.list_strdefs = ['H', 'e', 'l', 'l', 'o']
+        block.string_normal = "A"
+        block.string_values = "B"
+        block.string_named = "BC"
+        block.string_dynamic = "U"
+        block.string_multiline = "why\nhello\there"
+        block.string_multiline_reset = "indubitably"
+        block.string_html = "<strong>Testing!</strong>"
+        block.save()
+
+        orig_values = {field_name: getattr(block, field_name) for field_name in FancyXBlock.editable_fields}
+        # Reload the page:
+        self.go_to_view("studio_view")
+        self.fix_js_environment()
+
+        self.click_save()
+        block = self.load_root_xblock()  # Need to reload the block to bypass its cache
+        for field_name in FancyXBlock.editable_fields:
+            self.assertEqual(getattr(block, field_name), orig_values[field_name])
+            self.assertTrue(block.fields[field_name].is_set_on(block))

--- a/tests/integration/test_studio_editable.py
+++ b/tests/integration/test_studio_editable.py
@@ -175,11 +175,11 @@ class FancyXBlock(StudioEditableXBlockMixin, XBlock):
     A Studio-editable XBlock with lots of fields and fancy features
     """
     bool_normal = Boolean(display_name="Normal Boolean Field")
-    dict_normal = Dict(display_name="Normal Dictionary Field", default={})
+    dict_normal = Dict(display_name="Normal Dictionary Field")
     float_normal = Float(display_name="Normal Float Field")
     float_values = Float(display_name="Float Field With Values", values=(0, 2.718281, 3.14159,), default=0)
     int_normal = Integer(display_name="Normal Integer Field")
-    int_ranged = Integer(display_name="Ranged Integer Field", min=1, max=9, default=5, step=2)
+    int_ranged = Integer(display_name="Ranged Integer Field", values={"min": 0, "max": 10, "step": 2})
     int_dynamic = Integer(
         display_name="Integer Field With Dynamic Values",
         default=0,
@@ -194,7 +194,7 @@ class FancyXBlock(StudioEditableXBlockMixin, XBlock):
             {"display_name": "Maybe So", "value": -1},
         )
     )
-    list_normal = List(display_name="Normal List", default=[])
+    list_normal = List(display_name="Normal List")
     list_intdefs = List(display_name="Integer List With Default", default=[1, 2, 3, 4, 5])
     list_strdefs = List(display_name="String List With Default", default=['1', '2', '3', '4', '5'])
 
@@ -213,6 +213,11 @@ class FancyXBlock(StudioEditableXBlockMixin, XBlock):
     
     string_normal = String(display_name="Normal String Field")
     string_values = String(display_name="String Field With Values", default="A", values=("A", "B", "C", "D"))
+    string_values_provider = String(
+        display_name="String Field With Dynamic Values",
+        default="",
+        values_provider=lambda self: [unicode(self.scope_ids.usage_id), ""],
+    )
     string_named = String(
         display_name="String Field With Named Values",
         default="AB",
@@ -234,8 +239,8 @@ class FancyXBlock(StudioEditableXBlockMixin, XBlock):
     editable_fields = (
         'bool_normal', 'dict_normal', 'float_normal', 'float_values', 'int_normal', 'int_ranged', 'int_dynamic',
         'int_values', 'list_normal', 'list_intdefs', 'list_strdefs', 'list_set_ints', 'list_set_strings',
-        'string_normal', 'string_values', 'string_named', 'string_dynamic', 'string_multiline',
-        'string_multiline_reset', 'string_html',
+        'string_normal', 'string_values', 'string_values_provider', 'string_named', 'string_dynamic',
+        'string_multiline', 'string_multiline_reset', 'string_html',
     )
 
 
@@ -272,7 +277,7 @@ class TestFancyXBlock_StudioView(StudioEditableBaseTest):
         block.float_normal = 17.0
         block.float_values = 3.14159
         block.int_normal = 10
-        block.int_ranged = 7
+        block.int_ranged = 8
         block.int_dynamic = 0
         block.int_values = -1
         block.list_normal = []
@@ -282,6 +287,7 @@ class TestFancyXBlock_StudioView(StudioEditableBaseTest):
         block.list_set_strings = ["bob"]
         block.string_normal = "A"
         block.string_values = "B"
+        block.string_values_provider = unicode(block.scope_ids.usage_id)
         block.string_named = "BC"
         block.string_dynamic = "U"
         block.string_multiline = "why\nhello\there"
@@ -297,5 +303,9 @@ class TestFancyXBlock_StudioView(StudioEditableBaseTest):
         self.click_save()
         block = self.load_root_xblock()  # Need to reload the block to bypass its cache
         for field_name in FancyXBlock.editable_fields:
-            self.assertEqual(getattr(block, field_name), orig_values[field_name])
+            self.assertEqual(
+                getattr(block, field_name),
+                orig_values[field_name],
+                "{} should be unchanged".format(field_name)
+            )
             self.assertTrue(block.fields[field_name].is_set_on(block))

--- a/tests/integration/test_studio_editable.py
+++ b/tests/integration/test_studio_editable.py
@@ -161,6 +161,13 @@ class TestEditableXBlock_StudioView(StudioEditableBaseTest):
         self.click_save()
 
 
+def fancy_list_values_provider_a(block):
+    return [1, 2, 3, 4, 5]
+
+def fancy_list_values_provider_b(block):
+    return [{"display_name": "Robert", "value": "bob"}, {"display_name": "Alexandra", "value": "alex"}]
+
+
 class FancyXBlock(StudioEditableXBlockMixin, XBlock):
     """
     A Studio-editable XBlock with lots of fields and fancy features
@@ -188,6 +195,19 @@ class FancyXBlock(StudioEditableXBlockMixin, XBlock):
     list_normal = List(display_name="Normal List", default=[])
     list_intdefs = List(display_name="Integer List With Default", default=[1, 2, 3, 4, 5])
     list_strdefs = List(display_name="String List With Default", default=['1', '2', '3', '4', '5'])
+
+    list_set_ints = List(
+        display_name="Int List (Set)",
+        list_style="set",
+        list_values_provider=fancy_list_values_provider_a,
+        default=[1, 3, 5],
+    )
+    list_set_strings = List(
+        display_name="String List (Set)",
+        list_style="set",
+        list_values_provider=fancy_list_values_provider_b,
+        default=["alex"],
+    )
     
     string_normal = String(display_name="Normal String Field")
     string_values = String(display_name="String Field With Values", default="A", values=("A", "B", "C", "D"))
@@ -211,8 +231,9 @@ class FancyXBlock(StudioEditableXBlockMixin, XBlock):
 
     editable_fields = (
         'bool_normal', 'dict_normal', 'float_normal', 'float_values', 'int_normal', 'int_ranged', 'int_dynamic',
-        'int_values', 'list_normal', 'list_intdefs', 'list_strdefs', 'string_normal', 'string_values', 'string_named',
-        'string_dynamic', 'string_multiline', 'string_multiline_reset', 'string_html',
+        'int_values', 'list_normal', 'list_intdefs', 'list_strdefs', 'list_set_ints', 'list_set_strings',
+        'string_normal', 'string_values', 'string_named', 'string_dynamic', 'string_multiline',
+        'string_multiline_reset', 'string_html',
     )
 
 
@@ -255,6 +276,8 @@ class TestFancyXBlock_StudioView(StudioEditableBaseTest):
         block.list_normal = []
         block.list_intdefs = [9, 10, 11]
         block.list_strdefs = ['H', 'e', 'l', 'l', 'o']
+        block.list_set_ints = [2, 3, 4]
+        block.list_set_strings = ["bob"]
         block.string_normal = "A"
         block.string_values = "B"
         block.string_named = "BC"

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,0 +1,72 @@
+"""
+Tests for helpers.py
+"""
+import unittest
+from workbench.runtime import WorkbenchRuntime
+from xblock.core import XBlock
+from xblockutils.helpers import child_isinstance
+
+
+class DogXBlock(XBlock):
+    """ Test XBlock representing any dog. Raises error if instantiated. """
+    pass
+
+
+class GoldenRetrieverXBlock(DogXBlock):
+    """ Test XBlock representing a golden retriever """
+    pass
+
+
+class CatXBlock(XBlock):
+    """ Test XBlock representing any cat """
+    pass
+
+
+class BasicXBlock(XBlock):
+    """ Basic XBlock """
+    has_children = True
+
+
+class TestChildIsInstance(unittest.TestCase):
+    """
+    Test child_isinstance helper method, in the workbench runtime.
+    """
+    @XBlock.register_temp_plugin(GoldenRetrieverXBlock, "gr")
+    @XBlock.register_temp_plugin(CatXBlock, "cat")
+    @XBlock.register_temp_plugin(BasicXBlock, "block")
+    def setUp(self):
+        super(TestChildIsInstance, self).setUp()
+        self.runtime = WorkbenchRuntime()
+        self.root_id = self.runtime.parse_xml_string('<block> <block><cat/><gr/></block> <cat/> <gr/> </block>')
+
+    def test_child_isinstance(self):
+        """
+        Check that child_isinstance() works on direct children
+        """
+        root = self.runtime.get_block(self.root_id)
+        self.assertFalse(child_isinstance(root, root.children[0], DogXBlock))
+        self.assertFalse(child_isinstance(root, root.children[0], GoldenRetrieverXBlock))
+        self.assertTrue(child_isinstance(root, root.children[0], BasicXBlock))
+
+        self.assertFalse(child_isinstance(root, root.children[1], DogXBlock))
+        self.assertFalse(child_isinstance(root, root.children[1], GoldenRetrieverXBlock))
+        self.assertTrue(child_isinstance(root, root.children[1], CatXBlock))
+
+        self.assertFalse(child_isinstance(root, root.children[2], CatXBlock))
+        self.assertTrue(child_isinstance(root, root.children[2], DogXBlock))
+        self.assertTrue(child_isinstance(root, root.children[2], GoldenRetrieverXBlock))
+
+    def test_child_isinstance_descendants(self):
+        """
+        Check that child_isinstance() works on deeper descendants
+        """
+        root = self.runtime.get_block(self.root_id)
+        block = root.runtime.get_block(root.children[0])
+        self.assertIsInstance(block, BasicXBlock)
+
+        self.assertFalse(child_isinstance(root, block.children[0], DogXBlock))
+        self.assertTrue(child_isinstance(root, block.children[0], CatXBlock))
+
+        self.assertTrue(child_isinstance(root, block.children[1], DogXBlock))
+        self.assertTrue(child_isinstance(root, block.children[1], GoldenRetrieverXBlock))
+        self.assertFalse(child_isinstance(root, block.children[1], CatXBlock))

--- a/xblockutils/base_test.py
+++ b/xblockutils/base_test.py
@@ -115,7 +115,7 @@ class SeleniumBaseTest(SeleniumXBlockTest):
     """
     Selenium Base Test for loading a whole folder of XML scenarios and then running tests.
     This is kept for compatibility, but it is recommended that SeleniumXBlockTest be used
-    instead, since it is faster and more flexible (specifically, senarios are only loaded
+    instead, since it is faster and more flexible (specifically, scenarios are only loaded
     as needed, and can be defined inline with the tests).
     """
     module_name = None  # You must set this to __name__ in any subclass so ResourceLoader can find scenario XML files

--- a/xblockutils/base_test.py
+++ b/xblockutils/base_test.py
@@ -24,54 +24,30 @@ Base classes for Selenium or bok-choy based integration tests of XBlocks.
 import time
 
 from selenium.webdriver.support.ui import WebDriverWait
-
-from workbench import scenarios
+from workbench.runtime import WorkbenchRuntime
+from workbench.scenarios import SCENARIOS, add_xml_scenario, remove_scenario
 from workbench.test.selenium_test import SeleniumTest
 
 from .resources import ResourceLoader
 
 
-class SeleniumBaseTest(SeleniumTest):
+class SeleniumXBlockTest(SeleniumTest):
     """
-    Base class for Selenium integration tests of XBlocks, hosted in the workbench
+    Base class for using the workbench to test XBlocks with Selenium or bok-choy.
+
+    If you want to test an XBlock that's not already installed into the python environment,
+    you can use @XBlock.register_temp_plugin around your test method[s].
     """
-    module_name = None  # You must set this to __name__ in any subclass so ResourceLoader can find scenario XML files
-    default_css_selector = None  # Selector used by go_to_page to return the XBlock DOM element
-    relative_scenario_path = 'xml'
     timeout = 10  # seconds
 
-    @property
-    def _module_name(self):
-        """ Internal method to access module_name with a friendly warning if it's unset """
-        if self.module_name is None:
-            raise NotImplementedError("Overwrite cls.module_name in your derived class.")
-        return self.module_name
-
-    @property
-    def _default_css_selector(self):
-        """ Internal method to access default_css_selector with a warning if it's unset """
-        if self.default_css_selector is None:
-            raise NotImplementedError("Overwrite cls.default_css_selector in your derived class.")
-        return self.default_css_selector
-
     def setUp(self):
-        super(SeleniumBaseTest, self).setUp()
-
-        # Use test scenarios
-        self.browser.get(self.live_server_url)  # Needed to load tests once
-        scenarios.SCENARIOS.clear()
-        loader = ResourceLoader(self._module_name)
-        scenarios_list = loader.load_scenarios_from_path(self.relative_scenario_path, include_identifier=True)
-        for identifier, title, xml in scenarios_list:
-            scenarios.add_xml_scenario(identifier, title, xml)
-            self.addCleanup(scenarios.remove_scenario, identifier)
-
-        # Suzy opens the browser to visit the workbench
-        self.browser.get(self.live_server_url)
-
-        # She knows it's the site by the header
-        header1 = self.browser.find_element_by_css_selector('h1')
-        self.assertEqual(header1.text, 'XBlock scenarios')
+        super(SeleniumXBlockTest, self).setUp()
+        # Delete all scenarios from the workbench:
+        import workbench.urls  # Trigger initial scenario load. pylint: disable=unused-variable
+        SCENARIOS.clear()
+        # Disable CSRF checks on XBlock handlers:
+        import workbench.views
+        workbench.views.handler.csrf_exempt = True
 
     def wait_until_hidden(self, elem):
         """ Wait until the DOM element elem is hidden """
@@ -106,6 +82,75 @@ class SeleniumBaseTest(SeleniumTest):
             lambda driver: driver.find_element_by_css_selector(selector),
             u"Selector '{}' should exist.".format(selector)
         )
+
+    @staticmethod
+    def set_scenario_xml(xml):
+        """ Reset the workbench to have only one scenario with the specified XML """
+        SCENARIOS.clear()
+        add_xml_scenario("test", "Test Scenario", xml)
+
+    def go_to_view(self, view_name='student_view', student_id=None):
+        """
+        Navigate to the page `page_name`, as listed on the workbench home
+        Returns the DOM element on the visited page located by the `css_selector`
+        """
+        url = self.live_server_url + '/scenario/test/{}/'.format(view_name)
+        if student_id:
+            url += '?student={}'.format(student_id)
+        self.browser.get(url)
+        return self.browser.find_element_by_css_selector('.workbench .preview > div.xblock-v1:first-child')
+
+    def load_root_xblock(self):
+        """
+        Load (in Python) the XBlock at the root of the current scenario.
+        """
+        dom_node = self.browser.find_element_by_css_selector('.workbench .preview > div.xblock-v1:first-child')
+        usage_id = dom_node.get_attribute('data-usage')
+        student_id = "none"
+        runtime = WorkbenchRuntime(student_id)
+        return runtime.get_block(usage_id)
+
+
+class SeleniumBaseTest(SeleniumXBlockTest):
+    """
+    Selenium Base Test for loading a whole folder of XML scenarios and then running tests.
+    This is kept for compatibility, but it is recommended that SeleniumXBlockTest be used
+    instead, since it is faster and more flexible (specifically, senarios are only loaded
+    as needed, and can be defined inline with the tests).
+    """
+    module_name = None  # You must set this to __name__ in any subclass so ResourceLoader can find scenario XML files
+    default_css_selector = None  # Selector used by go_to_page to return the XBlock DOM element
+    relative_scenario_path = 'xml'  # Path from the module (module_name) to the secnario XML files
+
+    @property
+    def _module_name(self):
+        """ Internal method to access module_name with a friendly warning if it's unset """
+        if self.module_name is None:
+            raise NotImplementedError("Overwrite cls.module_name in your derived class.")
+        return self.module_name
+
+    @property
+    def _default_css_selector(self):
+        """ Internal method to access default_css_selector with a warning if it's unset """
+        if self.default_css_selector is None:
+            raise NotImplementedError("Overwrite cls.default_css_selector in your derived class.")
+        return self.default_css_selector
+
+    def setUp(self):
+        super(SeleniumBaseTest, self).setUp()
+        # Use test scenarios:
+        loader = ResourceLoader(self._module_name)
+        scenarios_list = loader.load_scenarios_from_path(self.relative_scenario_path, include_identifier=True)
+        for identifier, title, xml in scenarios_list:
+            add_xml_scenario(identifier, title, xml)
+            self.addCleanup(remove_scenario, identifier)
+
+        # Suzy opens the browser to visit the workbench
+        self.browser.get(self.live_server_url)
+
+        # She knows it's the site by the header
+        header1 = self.browser.find_element_by_css_selector('h1')
+        self.assertEqual(header1.text, 'XBlock scenarios')
 
     def go_to_page(self, page_name, css_selector=None, view_name=None):
         """

--- a/xblockutils/helpers.py
+++ b/xblockutils/helpers.py
@@ -5,11 +5,19 @@ Useful helper methods
 
 def child_isinstance(block, child_id, block_class_or_mixin):
     """
-    Is "block"'s child identified by usage_id "child_id" an instance of
-    "block_class_or_mixin"?
+    Efficiently check if a child of an XBlock is an instance of the given class.
 
-    This is a bit complicated since it avoids the need to actually
-    instantiate the child block.
+    Arguments:
+    block -- the parent (or ancestor) of the child block in question
+    child_id -- the usage key of the child block we are wondering about
+    block_class_or_mixin -- We return true if block's child indentified by child_id is an
+    instance of this.
+
+    This method is equivalent to
+
+        isinstance(block.runtime.get_block(child_id), block_class_or_mixin)
+
+    but is far more efficient, as it avoids the need to instantiate the child.
     """
     def_id = block.runtime.id_reader.get_definition_id(child_id)
     type_name = block.runtime.id_reader.get_block_type(def_id)

--- a/xblockutils/helpers.py
+++ b/xblockutils/helpers.py
@@ -1,0 +1,17 @@
+"""
+Useful helper methods
+"""
+
+
+def child_isinstance(block, child_id, block_class_or_mixin):
+    """
+    Is "block"'s child identified by usage_id "child_id" an instance of
+    "block_class_or_mixin"?
+
+    This is a bit complicated since it avoids the need to actually
+    instantiate the child block.
+    """
+    def_id = block.runtime.id_reader.get_definition_id(child_id)
+    type_name = block.runtime.id_reader.get_block_type(def_id)
+    child_class = block.runtime.load_block_type(type_name)
+    return issubclass(child_class, block_class_or_mixin)

--- a/xblockutils/public/studio_edit.js
+++ b/xblockutils/public/studio_edit.js
@@ -1,0 +1,79 @@
+/* Javascript for StudioEditableXBlockMixin. */
+function StudioEditableXBlockMixin(runtime, element) {
+    "use strict";
+    
+    var fields = [];
+    $(element).find('.field-data-control').each(function() {
+        var $field = $(this);
+        var $wrapper = $field.closest('li');
+        var $resetButton = $wrapper.find('button.setting-clear');
+        var cast = $wrapper.data('cast');
+        fields.push({
+            $field: $field,
+            name: $wrapper.data('field-name'),
+            isSet: function() { return $wrapper.hasClass('is-set'); },
+            val: function() {
+                var val = $field.val();
+                // Cast values to the appropriate type so that we send nice clean JSON over the wire:
+                if (cast == 'boolean')
+                    return (val == 'true' || val == '1');
+                if (cast == "integer")
+                    return parseInt(val, 10);
+                if (cast == "float")
+                    return parseFloat(val);
+                return val;
+            }
+        });
+        $field.bind("change input paste", function() {
+            // Field value has been modified:
+            $wrapper.addClass('is-set');
+            $resetButton.removeClass('inactive').addClass('active');
+        });
+        $resetButton.click(function() {
+            $field.val($wrapper.data('default'));
+            $wrapper.removeClass('is-set');
+            $resetButton.removeClass('active').addClass('inactive');
+        });
+    });
+
+    var studio_submit = function(data) {
+        var handlerUrl = runtime.handlerUrl(element, 'submit_studio_edits');
+        runtime.notify('save', {state: 'start', message: gettext("Saving")});
+        $.ajax({
+            type: "POST",
+            url: handlerUrl,
+            data: JSON.stringify(data),
+            dataType: "json",
+            global: false,  // Disable Studio's error handling that conflicts with studio's notify('save') and notify('cancel') :-/
+            success: function(response) { runtime.notify('save', {state: 'end'}); }
+        }).fail(function(jqXHR) {
+            var message = gettext("This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online.");
+            if (jqXHR.responseText) { // Is there a more specific error message we can show?
+                try {
+                    message = JSON.parse(jqXHR.responseText).error;
+                } catch (error) { message = jqXHR.responseText.substr(0, 300); }
+            }
+            runtime.notify('error', {title: gettext("Unable to update settings"), message: message});
+        });
+    };
+
+    $('.save-button', element).bind('click', function(e) {
+        e.preventDefault();
+        var values = {};
+        var notSet = []; // List of field names that should be set to default values
+        for (var i in fields) {
+            var field = fields[i];
+            if (field.isSet()) {
+                values[field.name] = field.val();
+            } else {
+                notSet.push(field.name);
+            }
+        }
+        studio_submit({values: values, defaults: notSet});
+    });
+
+    $(element).find('.cancel-button').bind('click', function(e) {
+        e.preventDefault();
+        runtime.notify('cancel', {});
+    });
+}

--- a/xblockutils/public/studio_edit.js
+++ b/xblockutils/public/studio_edit.js
@@ -81,6 +81,10 @@ function StudioEditableXBlockMixin(runtime, element) {
             if (jqXHR.responseText) { // Is there a more specific error message we can show?
                 try {
                     message = JSON.parse(jqXHR.responseText).error;
+                    if (typeof message === "object" && message.messages) {
+                        // e.g. {"error": {"messages": [{"text": "Unknown user 'bob'!", "type": "error"}, ...]}} etc.
+                        message = $.map(message.messages, function(msg) { return msg.text; }).join(", ");
+                    }
                 } catch (error) { message = jqXHR.responseText.substr(0, 300); }
             }
             runtime.notify('error', {title: gettext("Unable to update settings"), message: message});

--- a/xblockutils/public/studio_edit.js
+++ b/xblockutils/public/studio_edit.js
@@ -23,6 +23,13 @@ function StudioEditableXBlockMixin(runtime, element) {
                     return parseInt(val, 10);
                 if (type == "float")
                     return parseFloat(val);
+                if (type == "generic") {
+                    val = val.trim();
+                    if (val === "")
+                        val = null;
+                    else
+                        val = JSON.parse(val); // TODO: handle parse errors
+                }
                 return val;
             }
         });
@@ -33,7 +40,7 @@ function StudioEditableXBlockMixin(runtime, element) {
         };
         $field.bind("change input paste", fieldChanged);
         $resetButton.click(function() {
-            $field.val($wrapper.data('default'));
+            $field.val($wrapper.attr('data-default')); // Use attr instead of data to force treating the default value as a string
             $wrapper.removeClass('is-set');
             $resetButton.removeClass('active').addClass('inactive');
         });

--- a/xblockutils/public/studio_edit.js
+++ b/xblockutils/public/studio_edit.js
@@ -11,7 +11,6 @@ function StudioEditableXBlockMixin(runtime, element) {
         var $resetButton = $wrapper.find('button.setting-clear');
         var type = $wrapper.data('cast');
         fields.push({
-            $field: $field,
             name: $wrapper.data('field-name'),
             isSet: function() { return $wrapper.hasClass('is-set'); },
             val: function() {
@@ -23,7 +22,7 @@ function StudioEditableXBlockMixin(runtime, element) {
                     return parseInt(val, 10);
                 if (type == "float")
                     return parseFloat(val);
-                if (type == "generic") {
+                if (type == "generic" || type == "list" || type == "set") {
                     val = val.trim();
                     if (val === "")
                         val = null;
@@ -64,6 +63,43 @@ function StudioEditableXBlockMixin(runtime, element) {
                 }
             });
         }
+    });
+
+    $(element).find('.wrapper-list-settings .list-set').each(function() {
+        var $optionList = $(this);
+        var $checkboxes = $(this).find('input');
+        var $wrapper = $optionList.closest('li');
+        var $resetButton = $wrapper.find('button.setting-clear');
+
+        fields.push({
+            name: $wrapper.data('field-name'),
+            isSet: function() { return $wrapper.hasClass('is-set'); },
+            val: function() {
+                var val = [];
+                $checkboxes.each(function() {
+                    if ($(this).is(':checked')) {
+                        val.push(JSON.parse($(this).val()));
+                    }
+                });
+                return val;
+            }
+        });
+        var fieldChanged = function() {
+            // Field value has been modified:
+            $wrapper.addClass('is-set');
+            $resetButton.removeClass('inactive').addClass('active');
+        };
+        $checkboxes.bind("change input", fieldChanged);
+
+        $resetButton.click(function() {
+            var defaults = JSON.parse($wrapper.attr('data-default'));
+            $checkboxes.each(function() {
+                var val = JSON.parse($(this).val());
+                $(this).prop('checked', defaults.indexOf(val) > -1);
+            });
+            $wrapper.removeClass('is-set');
+            $resetButton.removeClass('active').addClass('inactive');
+        });
     });
 
     var studio_submit = function(data) {

--- a/xblockutils/studio_editable.py
+++ b/xblockutils/studio_editable.py
@@ -10,6 +10,7 @@ StudioEditableXBlockMixin to your XBlock.
 
 # Imports ###########################################################
 
+import json
 import logging
 
 from xblock.core import XBlock
@@ -106,6 +107,10 @@ class StudioEditableXBlockMixin(object):
                 break
         if "type" not in info:
             raise NotImplementedError("StudioEditableXBlockMixin currently only supports fields derived from JSONField")
+        if info["type"] == "generic":
+            # Convert value to JSON string if we're treating this field generically:
+            info["value"] = json.dumps(info["value"])
+            info["default"] = json.dumps(info["default"])
         if field.values and not isinstance(field, Boolean):
             info['has_values'] = True
             # This field has only a limited number of pre-defined options.

--- a/xblockutils/studio_editable.py
+++ b/xblockutils/studio_editable.py
@@ -13,6 +13,7 @@ StudioEditableXBlockMixin to your XBlock.
 import json
 import logging
 
+from django.utils.translation import ugettext
 from xblock.core import XBlock
 from xblock.fields import Scope, JSONField, List, Integer, Float, Boolean, String
 from xblock.exceptions import JsonHandlerError
@@ -107,12 +108,12 @@ class StudioEditableXBlockMixin(object):
         )
         info = {
             'name': field_name,
-            'display_name': field.display_name,
+            'display_name': ugettext(field.display_name) if field.display_name else "",
             'is_set': field.is_set_on(self),
             'default': field.default,
             'value': field.read_from(self),
             'has_values': False,
-            'help': field.help,
+            'help': ugettext(field.help) if field.help else "",
             'allow_reset': field.runtime_options.get('resettable_editor', True),
             'list_values': None,  # Only available for List fields
             'has_list_values': False,  # True if list_values_provider exists, even if it returned no available options

--- a/xblockutils/studio_editable.py
+++ b/xblockutils/studio_editable.py
@@ -126,7 +126,7 @@ class StudioEditableXBlockMixin(object):
             else:
                 # e.g. [1, 2, 3] or [ {"display_name": "Always", "value": "always"}, {...}, ... ]
                 values = field.values
-                if "display_name" not in values[0]:
+                if not isinstance(values[0], dict) or "display_name" not in values[0]:
                     values = [{"display_name": val, "value": val} for val in values]
                 info['values'] = values
         return info

--- a/xblockutils/studio_editable.py
+++ b/xblockutils/studio_editable.py
@@ -91,13 +91,18 @@ class StudioEditableXBlockMixin(object):
             'value': field.read_from(self),
             'has_values': False,
             'help': field.help,
+            'allow_reset': field.runtime_options.get('resettable_editor', True),
         }
         for type_class, type_name in supported_field_types:
             if isinstance(field, type_class):
                 info['type'] = type_name
                 # If String fields are declared like String(..., multiline_editor=True), then call them "text" type:
-                if type_class is String and field.runtime_options.get('multiline_editor'):
-                    info['type'] = 'text'
+                editor_type = field.runtime_options.get('multiline_editor')
+                if type_class is String and editor_type:
+                    if editor_type == "html":
+                        info['type'] = 'html'
+                    else:
+                        info['type'] = 'text'
                 break
         if "type" not in info:
             raise NotImplementedError("StudioEditableXBlockMixin currently only supports fields derived from JSONField")

--- a/xblockutils/studio_editable.py
+++ b/xblockutils/studio_editable.py
@@ -127,7 +127,11 @@ class StudioEditableXBlockMixin(object):
             # Convert value to JSON string if we're treating this field generically:
             info["value"] = json.dumps(info["value"])
             info["default"] = json.dumps(info["default"])
-        if field.values and not isinstance(field, Boolean):
+        if 'values_provider' in field.runtime_options:
+            values = field.runtime_options["values_provider"](self)
+        else:
+            values = field.values
+        if values and not isinstance(field, Boolean):
             info['has_values'] = True
             # This field has only a limited number of pre-defined options.
             # Protip: when defining the field, values= can be a callable.
@@ -138,7 +142,6 @@ class StudioEditableXBlockMixin(object):
                 info["step"] = field.values["step"]
             else:
                 # e.g. [1, 2, 3] or [ {"display_name": "Always", "value": "always"}, {...}, ... ]
-                values = field.values
                 if not isinstance(values[0], dict) or "display_name" not in values[0]:
                     values = [{"display_name": val, "value": val} for val in values]
                 info['values'] = values

--- a/xblockutils/studio_editable.py
+++ b/xblockutils/studio_editable.py
@@ -26,6 +26,8 @@ from xblockutils.resources import ResourceLoader
 log = logging.getLogger(__name__)
 loader = ResourceLoader(__name__)
 
+# Classes ###########################################################
+
 
 class FutureFields(object):
     """
@@ -35,6 +37,7 @@ class FutureFields(object):
         self._new_fields_dict = new_fields_dict
         self._blacklist = newly_removed_fields
         self._fallback_obj = fallback_obj
+
     def __getattr__(self, name):
         try:
             return self._new_fields_dict[name]

--- a/xblockutils/studio_editable.py
+++ b/xblockutils/studio_editable.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015 OpenCraft
+# License: AGPLv3
+"""
+This module contains a mixin that allows third party XBlocks to be easily edited within edX
+Studio just like the built-in modules. No configuration required, just add
+StudioEditableXBlockMixin to your XBlock.
+"""
+
+# Imports ###########################################################
+
+import logging
+
+from xblock.core import XBlock
+from xblock.fields import Scope, JSONField, Integer, Float, Boolean, String
+from xblock.exceptions import JsonHandlerError
+from xblock.fragment import Fragment
+from xblock.validation import Validation
+
+from xblockutils.resources import ResourceLoader
+
+# Globals ###########################################################
+
+log = logging.getLogger(__name__)
+loader = ResourceLoader(__name__)
+
+
+class FutureFields(object):
+    """
+    A helper class whose attribute values come from the specified dictionary or fallback object.
+    """
+    def __init__(self, new_fields_dict, newly_removed_fields, fallback_obj):
+        self._new_fields_dict = new_fields_dict
+        self._blacklist = newly_removed_fields
+        self._fallback_obj = fallback_obj
+    def __getattr__(self, name):
+        try:
+            return self._new_fields_dict[name]
+        except KeyError:
+            if name in self._blacklist:
+                # Pretend like this field is not actually set, since we're going to be resetting it to default
+                return self._fallback_obj.fields[name].default
+            return getattr(self._fallback_obj, name)
+
+
+class StudioEditableXBlockMixin(object):
+    """
+    An XBlock mixin to provide a configuration UI for an XBlock in Studio.
+    """
+    editable_fields = ()  # Set this to a list of the names of fields to appear in the editor
+
+    def studio_view(self, context):
+        """
+        Render a form for editing this XBlock
+        """
+        fragment = Fragment()
+        context = {'fields': []}
+        # Build a list of all the fields that can be edited:
+        for field_name in self.editable_fields:
+            field = self.fields[field_name]
+            assert field.scope in (Scope.content, Scope.settings), (
+                "Only Scope.content or Scope.settings fields can be used with "
+                "StudioEditableXBlockMixin. Other scopes are for user-specific data and are "
+                "not generally created/configured by content authors in Studio."
+            )
+            field_info = self._make_field_info(field_name, field)
+            if field_info is not None:
+                context["fields"].append(field_info)
+        fragment.content = loader.render_template('templates/studio_edit.html', context)
+        fragment.add_javascript(loader.load_unicode('public/studio_edit.js'))
+        fragment.initialize_js('StudioEditableXBlockMixin')
+        return fragment
+
+    def _make_field_info(self, field_name, field):
+        """
+        Create the information that the template needs to render a form field for this field.
+        """
+        supported_field_types = (
+            (Integer, 'integer'),
+            (Float, 'float'),
+            (Boolean, 'boolean'),
+            (String, 'string'),
+            (JSONField, 'generic'),  # This is last so as a last resort we display a text field w/ the JSON string
+        )
+        info = {
+            'name': field_name,
+            'display_name': field.display_name,
+            'is_set': field.is_set_on(self),
+            'default': field.default,
+            'value': field.read_from(self),
+            'has_values': False,
+            'help': field.help,
+        }
+        for type_class, type_name in supported_field_types:
+            if isinstance(field, type_class):
+                info['type'] = type_name
+                # If String fields are declared like String(..., multiline_editor=True), then call them "text" type:
+                if type_class is String and field.runtime_options.get('multiline_editor'):
+                    info['type'] = 'text'
+                break
+        if "type" not in info:
+            raise NotImplementedError("StudioEditableXBlockMixin currently only supports fields derived from JSONField")
+        if field.values and not isinstance(field, Boolean):
+            info['has_values'] = True
+            # This field has only a limited number of pre-defined options.
+            # Protip: when defining the field, values= can be a callable.
+            if isinstance(field.values, dict) and isinstance(field, (Float, Integer)):
+                # e.g. {"min": 0 , "max": 10, "step": .1}
+                info["min"] = field.values["min"]
+                info["max"] = field.values["max"]
+                info["step"] = field.values["step"]
+            else:
+                # e.g. [1, 2, 3] or [ {"display_name": "Always", "value": "always"}, {...}, ... ]
+                values = field.values
+                if "display_name" not in values[0]:
+                    values = [{"display_name": val, "value": val} for val in values]
+                info['values'] = values
+        return info
+
+    @XBlock.json_handler
+    def submit_studio_edits(self, data, suffix=''):
+        """
+        AJAX handler for studio_view() Save button
+        """
+        values = {}  # dict of new field values we are updating
+        to_reset = []  # list of field names to delete from this XBlock
+        for field_name in self.editable_fields:
+            field = self.fields[field_name]
+            if field_name in data['values']:
+                if isinstance(field, JSONField):
+                    values[field_name] = field.from_json(data['values'][field_name])
+                else:
+                    raise JsonHandlerError(400, "Unsupported field type: {}".format(field_name))
+            elif field_name in data['defaults'] and field.is_set_on(self):
+                to_reset.append(field_name)
+        self.clean_studio_edits(values)
+        validation = Validation(self.scope_ids.usage_id)
+        # We cannot set the fields on self yet, because even if validation fails, studio is going to save any changes we
+        # make. So we create a "fake" object that has all the field values we are about to set.
+        preview_data = FutureFields(
+            new_fields_dict=values,
+            newly_removed_fields=to_reset,
+            fallback_obj=self
+        )
+        self.validate_field_data(validation, preview_data)
+        if validation:
+            for field_name, value in values.iteritems():
+                setattr(self, field_name, value)
+            for field_name in to_reset:
+                self.fields[field_name].delete_from(self)
+            return {'result': 'success'}
+        else:
+            raise JsonHandlerError(400, validation.to_json())
+
+    def clean_studio_edits(self, data):
+        """
+        Given POST data dictionary 'data', clean the data before validating it.
+        e.g. fix capitalization, remove trailing spaces, etc.
+        """
+        # Example:
+        # if "name" in data:
+        #     data["name"] = data["name"].strip()
+        pass
+
+    def validate_field_data(self, validation, data):
+        """
+        Validate this block's field data. Instead of checking fields like self.name, check the
+        fields set on data, e.g. data.name. This allows the same validation method to be re-used
+        for the studio editor. Any errors found should be added to "validation".
+
+        This method should not return any value or raise any exceptions.
+        All of this XBlock's fields should be found in "data", even if they aren't being changed
+        or aren't even set (i.e. are defaults).
+        """
+        # Example:
+        # if data.count <=0:
+        #     validation.add(ValidationMessage(ValidationMessage.ERROR, u"Invalid count"))
+        pass
+
+    def validate(self):
+        """
+        Validates the state of this XBlock.
+
+        Subclasses should override validate_field_data() to validate fields and override this
+        only for validation not related to this block's field values.
+        """
+        validation = super(StudioEditableXBlockMixin, self).validate()
+        self.validate_field_data(validation, self)
+        return validation

--- a/xblockutils/studio_editable.py
+++ b/xblockutils/studio_editable.py
@@ -98,7 +98,7 @@ class StudioEditableXBlockMixin(object):
             'help': field.help,
             'allow_reset': field.runtime_options.get('resettable_editor', True),
             'list_values': None,  # Only available for List fields
-            'list_values_count': None,
+            'has_list_values': False,  # True if list_values_provider exists, even if it returned no available options
         }
         for type_class, type_name in supported_field_types:
             if isinstance(field, type_class):
@@ -153,7 +153,7 @@ class StudioEditableXBlockMixin(object):
                 for entry in list_values:
                     entry["value"] = json.dumps(entry["value"])
             info['list_values'] = list_values
-            info['list_values_count'] = len(list_values)
+            info['has_list_values'] = True
         return info
 
     @XBlock.json_handler

--- a/xblockutils/studio_editable_test.py
+++ b/xblockutils/studio_editable_test.py
@@ -1,0 +1,60 @@
+"""
+Tests for StudioEditableXBlockMixin
+"""
+from selenium.webdriver.support.ui import WebDriverWait
+from xblockutils.base_test import SeleniumXBlockTest
+
+
+class StudioEditableBaseTest(SeleniumXBlockTest):
+    """
+    Base class that can be used for integration tests of any XBlocks that use
+    StudioEditableXBlockMixin
+    """
+    def click_save(self, expect_success=True):
+        """ Click on the save button """
+        # Click 'Save':
+        self.browser.find_element_by_link_text('Save').click()
+        # Before saving the block changes, the runtime should get a 'save' notice:
+        notification = self.dequeue_runtime_notification()
+        self.assertEqual(notification[0], "save")
+        self.assertEqual(notification[1]["state"], "start")
+        if expect_success:
+            notification = self.dequeue_runtime_notification()
+            self.assertEqual(notification[0], "save")
+            self.assertEqual(notification[1]["state"], "end")
+
+    def fix_js_environment(self):
+        """ Make the Workbench JS runtime more compatibile with Studio's """
+        # Mock gettext()
+        self.browser.execute_script('window.gettext = function(t) { return t; };')
+        # Mock runtime.notify() so we can watch for notify events like 'save'
+        self.browser.execute_script(
+            'window.notifications = [];'
+            'window.RuntimeProvider.getRuntime(1).notify = function() {'
+            '    window.notifications.push(arguments);'
+            '};'
+        )
+
+    def dequeue_runtime_notification(self, wait_first=True):
+        """
+        Return the oldest call from JavaScript to block.runtime.notify() that we haven't yet
+        seen here in Python-land. Waits for a notification unless wait_first is False.
+        """
+        if wait_first:
+            self.wait_for_runtime_notification()
+        return self.browser.execute_script('return window.notifications.shift();')
+
+    def wait_for_runtime_notification(self):
+        """ Wait until runtime.notify() has been called """
+        wait = WebDriverWait(self.browser, self.timeout)
+        wait.until(lambda driver: driver.execute_script('return window.notifications.length > 0;'))
+
+    def get_element_for_field(self, field_name):
+        """ Given the name of a field, return the DOM element for its form control """
+        selector = "li.field[data-field-name={}] .field-data-control".format(field_name)
+        return self.browser.find_element_by_css_selector(selector)
+
+    def click_reset_for_field(self, field_name):
+        """ Click the reset button next to the specified setting field """
+        selector = "li.field[data-field-name={}] .setting-clear".format(field_name)
+        self.browser.find_element_by_css_selector(selector).click()

--- a/xblockutils/templates/studio_edit.html
+++ b/xblockutils/templates/studio_edit.html
@@ -54,9 +54,9 @@
               >
             {% elif field.type == "text" or field.type == "html" %}
               <textarea class="field-data-control" data-field-name="{{field.name}}" id="xb-field-edit-{{field.name}}" rows=10 cols=70>{{field.value}}</textarea>
-            {% elif field.type == 'set' and field.list_values %}
+            {% elif field.type == 'set' and field.has_list_values %}
               {% comment %}
-                TODO: If list_values_count is high, show an alternate editor 
+                TODO: If len(list_values) is high, show an alternate editor 
                 with a select box and a growing list of selected choices
               {% endcomment %}
               <div class="wrapper-list-settings">
@@ -73,6 +73,8 @@
                         {{choice.display_name}}
                       </label>
                     </li>
+                  {% empty %}
+                    <li>{% trans "No choices available." %}</li>
                   {% endfor %}
                 </ul>
               </div>

--- a/xblockutils/templates/studio_edit.html
+++ b/xblockutils/templates/studio_edit.html
@@ -1,0 +1,85 @@
+{% load i18n %}
+<div class="editor-with-buttons">
+  <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
+    <ul class="list-input settings-list">
+      {% for field in fields %}
+        <li
+          class="field comp-setting-entry metadata_entry {% if field.is_set %}is-set{% endif %}"
+          data-field-name="{{field.name}}"
+          data-default="{% if field.type == 'boolean' %}{{ field.default|yesno:'1,0' }}{% else %}{{ field.default|default_if_none:"" }}{% endif %}"
+          data-cast="{{field.type}}"
+        >
+          <div class="wrapper-comp-setting">
+            <label class="label setting-label" for="xb-field-edit-{{field.name}}">{{field.display_name}}</label>
+
+            {% if field.type == "boolean" %}
+              <select
+                class="field-data-control"
+                id="xb-field-edit-{{field.name}}"
+              >
+                <option value="1" {% if field.value %}selected{% endif %}>
+                  True {% if field.default %}&nbsp;&nbsp;&nbsp;&nbsp;(Default){% endif %}
+                </option>
+                <option value="0" {% if not field.value %}selected{% endif %}>
+                  False {% if not field.default %}&nbsp;&nbsp;&nbsp;&nbsp;(Default){% endif %}
+                </option>
+              </select>
+            {% elif field.has_values %}
+              <select
+                class="field-data-control"
+                id="xb-field-edit-{{field.name}}"
+              >
+                {% for option in field.values %}
+                  <option value="{{option.value}}" {% if field.value == option.value %}selected{% endif %}>
+                    {{option.display_name}} {% if option.value == field.default %}&nbsp;&nbsp;&nbsp;&nbsp;(Default){% endif %}
+                  </option>
+                {% endfor %}
+              </select>
+            {% elif field.type == "string" %}
+              <input
+                type="text"
+                class="field-data-control"
+                id="xb-field-edit-{{field.name}}"
+                value="{{field.value|default_if_none:""}}"
+              >
+            {% elif field.type == "integer" or field.type == "float" %}
+              <input
+                type="number"
+                class="field-data-control"
+                id="xb-field-edit-{{field.name}}"
+                {% if field.step %} step="{{field.step}}" {% elif field.type == "integer" %} step=1 {% endif %}
+                {% if field.max %} max="{{field.max}}" {% endif %}
+                {% if field.min %} min="{{field.min}}" {% endif %}
+                value="{{field.value|default_if_none:""}}"
+              >
+            {% elif field.type == "text" %}
+              <textarea class="field-data-control" data-field-name="{{field.name}}" id="xb-field-edit-{{field.name}}" rows=10 cols=70>{{field.value}}</textarea>
+            {% elif field.type == 'generic' %}
+              {# Show a textarea so we can edit it as a JSON string #}
+              <textarea class="field-data-control" data-field-name="{{field.name}}" id="xb-field-edit-{{field.name}}" rows=5 cols=70>{{field.value}}</textarea>
+            {% else %}
+              Unsupported field type. This setting cannot be edited.
+            {% endif %}
+            <button class="action setting-clear {% if field.is_set %}active{%else%}inactive{% endif %}" type="button" name="setting-clear" value="{% trans "Clear" %}" data-tooltip="{% trans "Clear" %}">
+              <i class="icon fa fa-undo"></i><span class="sr">{% trans "Clear Value" %}</span>
+            </button>
+          </div>
+          {% if field.help %}
+            <span class="tip setting-help"> {{ field.help }} </span>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="xblock-actions">
+    <ul>
+      <li class="action-item">
+        <a href="#" class="button action-primary save-button">{% trans "Save" %}</a>
+      </li>
+
+      <li class="action-item">
+        <a href="#" class="button cancel-button">{% trans "Cancel" %}</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/xblockutils/templates/studio_edit.html
+++ b/xblockutils/templates/studio_edit.html
@@ -74,7 +74,7 @@
                       </label>
                     </li>
                   {% empty %}
-                    <li>{% trans "No choices available." %}</li>
+                    <li>{% trans "None Available" %}</li>
                   {% endfor %}
                 </ul>
               </div>

--- a/xblockutils/templates/studio_edit.html
+++ b/xblockutils/templates/studio_edit.html
@@ -52,7 +52,7 @@
                 {% if field.min %} min="{{field.min}}" {% endif %}
                 value="{{field.value|default_if_none:""}}"
               >
-            {% elif field.type == "text" %}
+            {% elif field.type == "text" or field.type == "html" %}
               <textarea class="field-data-control" data-field-name="{{field.name}}" id="xb-field-edit-{{field.name}}" rows=10 cols=70>{{field.value}}</textarea>
             {% elif field.type == 'generic' %}
               {# Show a textarea so we can edit it as a JSON string #}
@@ -60,9 +60,12 @@
             {% else %}
               Unsupported field type. This setting cannot be edited.
             {% endif %}
-            <button class="action setting-clear {% if field.is_set %}active{%else%}inactive{% endif %}" type="button" name="setting-clear" value="{% trans "Clear" %}" data-tooltip="{% trans "Clear" %}">
-              <i class="icon fa fa-undo"></i><span class="sr">{% trans "Clear Value" %}</span>
-            </button>
+
+            {% if field.allow_reset %}
+              <button class="action setting-clear {% if field.is_set %}active{%else%}inactive{% endif %}" type="button" name="setting-clear" value="{% trans "Clear" %}" data-tooltip="{% trans "Clear" %}">
+                <i class="icon fa fa-undo"></i><span class="sr">{% trans "Clear Value" %}</span>
+              </button>
+            {% endif %}
           </div>
           {% if field.help %}
             <span class="tip setting-help"> {{ field.help }} </span>

--- a/xblockutils/templates/studio_edit.html
+++ b/xblockutils/templates/studio_edit.html
@@ -9,7 +9,7 @@
           data-default="{% if field.type == 'boolean' %}{{ field.default|yesno:'1,0' }}{% else %}{{ field.default|default_if_none:"" }}{% endif %}"
           data-cast="{{field.type}}"
         >
-          <div class="wrapper-comp-setting">
+          <div class="wrapper-comp-setting{% if field.type == "set" %} metadata-list-enum {%endif%}">
             <label class="label setting-label" for="xb-field-edit-{{field.name}}">{{field.display_name}}</label>
 
             {% if field.type == "boolean" %}
@@ -54,7 +54,29 @@
               >
             {% elif field.type == "text" or field.type == "html" %}
               <textarea class="field-data-control" data-field-name="{{field.name}}" id="xb-field-edit-{{field.name}}" rows=10 cols=70>{{field.value}}</textarea>
-            {% elif field.type == 'generic' %}
+            {% elif field.type == 'set' and field.list_values %}
+              {% comment %}
+                TODO: If list_values_count is high, show an alternate editor 
+                with a select box and a growing list of selected choices
+              {% endcomment %}
+              <div class="wrapper-list-settings">
+                <ul class="list-settings list-set">
+                  {% for choice in field.list_values %}
+                    <li class="list-settings-item">
+                      <label>
+                        <input
+                          type="checkbox"
+                          value="{{choice.value}}"
+                          style="width:auto;height:auto;"
+                          {% if choice.value in field.value %}checked="checked"{% endif %}
+                        >
+                        {{choice.display_name}}
+                      </label>
+                    </li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% elif field.type == 'generic' or field.type == 'list' or field.type == 'set' %}
               {# Show a textarea so we can edit it as a JSON string #}
               <textarea class="field-data-control" data-field-name="{{field.name}}" id="xb-field-edit-{{field.name}}" rows=5 cols=70>{{field.value}}</textarea>
             {% else %}


### PR DESCRIPTION
This PR contains two very useful mixin classes available for use in XBlocks:

## StudioEditableXBlockMixin

This mixin will automatically generate a working `studio_view` form that allows content authors to edit the fields of your XBlock. To use, simply add the class to your base class list, and add a new class field called `editable_fields`, set to a tuple of the names of the fields you want your user to be able to edit.

```python
@XBlock.needs("i18n")
class ExampleBlock(StudioEditableXBlockMixin, XBlock):
    ...
    mode = String(
        display_name="Mode",
        help="Determines the behaviour of this component. Standard is recommended.",
        default='standard',
        scope=Scope.content,
        values=('standard', 'crazy')
    )
    editable_fields = ('mode', 'display_name')
```

That's all you need to do. The mixin will read the optional `display_name`, `help`, `default`, and `values` settings from the fields you mention and build the editor form as well as an AJAX save handler.

If you want to validate the data, you can override `validate_field_data(self, validation, data)` and/or ` clean_studio_edits(self, data)` - see the source code for details.

Supported field types:
* Boolean: `field_name = Boolean(display_name="Field Name")`
* Float:`field_name = Float(display_name="Field Name")`
* Integer: `field_name = Integer(display_name="Field Name")`
* String: `field_name = String(display_name="Field Name")`
* String (multiline): `field_name = String(multiline_editor=True, resettable_editor=False)`
* String (html): `field_name = String(multiline_editor='html', resettable_editor=False)`
* List (set): `field_name = List(list_style='set', list_values_provider=some_method, default=[])`
  - So far a special editor is only implemented for unordered lists of unique values chosen from a small number of options. For any other type of `List`, the editor UI will be a JSON textarea.
  - The `List` declaration must include the property `list_style='set'` to indicate this.
  - The `List` declaration must also define a `list_values_provider` method which will be called with the block as its only parameter and which must return a list of possible values.
* Any of the above will use a dropdown menu if they have a pre-defined list of possible values.
* Rudimentary support for List, Dict, and any other JSONField-derived field types
  - `list_field = List(display_name="Normal List", default=[])`
  - `dict_field = Dict(display_name="Normal Dict", default={})`

Supported field options (all field types):
* `values` can define a list of possible options, changing the UI element to a select box. Values can be set to any of the formats [defined in the XBlock source code](https://github.com/edx/XBlock/blob/master/xblock/fields.py):
  - A finite set of elements: `[1, 2, 3]`
  - A finite set of elements where the display names differ from the values:
    ```
            [
             {"display_name": "Always", "value": "always"},
             {"display_name": "Past Due", "value": "past_due"},
            ]
    ```
  - A range for floating point numbers with specific increments: `{"min": 0 , "max": 10, "step": .1}`
  - A callable that returns one of the above. (Note: the callable does *not* get passed the XBlock instance or runtime, so it cannot be a normal member function)
* `resettable_editor` - defaults to `True`. Set `False` to hide the "Reset" button used to return a field to its default value by removing the field's value from the XBlock instance.

Changes compared to the existing XModule editing support in Studio:
* Editable fields are defined in a simple string-based whitelist (`editable_fields`) rather than blacklist (`non_editable_metadata_fields`)
* Can distinguish between a String field value explicitly set to `""` and a field using the default value of `""`. Studio's XModule field editor cannot.
* Can share field data validation logic with the XBlock's existing validation code - reduces code duplication
* Nicer editor for `List` fields that are really sets (unordered, unique items)

Basic screenshot:
![Basic screenshot](https://cloud.githubusercontent.com/assets/945577/6341782/7d237966-bb83-11e4-9344-faa647056999.png)

Screenshot of the list/set editor:
![Screenshot of the list or set editor](https://cloud.githubusercontent.com/assets/945577/6404805/f03c91b8-bdd0-11e4-8310-5b7090fa8a6a.png)


## StudioContainerXBlockMixin

This mixin helps with creating XBlocks that want to allow content authors to add/remove/reorder child blocks. By removing any existing `author_view` and adding this mixin, you'll get editable, re-orderable, deletable child support in Studio. To enable authors to add new children, simply override `author_edit_view` and set `can_add=True` when calling `render_children` - see the source code. To enable authors to add only a limited subset of children requires custom HTML.

An example is the mentoring XBlock:
![screen shot 2015-02-23 at 5 44 05 pm](https://cloud.githubusercontent.com/assets/945577/6341803/d0195ec4-bb83-11e4-82f6-8052c9f70690.png)


## Other changes
* Added `child_isinstance()` helper method, which uses only the public XBlock API to test a block's class given a usage_id, without the expensive operation of instantiating the block.
  - Despite the slightly convoluted code, with an edX split modulestore runtime this is at least [two orders of magnitude faster](https://gist.github.com/bradenmacdonald/0305ff697d09a653673b) than instantiating the block before checking the instance.
* Sped up `SeleniumBaseTest` by removing the initial step of loading the Workbench home page
* Added a new class for Selenium/bok_choy tests, `SeleniumXBlockTest`. It is faster and more flexible than `SeleniumBaseTest ` because it doesn't need to load a whole folder of XML scenarios. `SeleniumBaseTest ` is kept to preserve compatibility for XBlock tests that currently use it.