### PR TITLE
Allow using HTML with list_values_provider

### DIFF
--- a/xblockutils/templates/studio_edit.html
+++ b/xblockutils/templates/studio_edit.html
@@ -63,13 +63,14 @@
                 <ul class="list-settings list-set">
                   {% for choice in field.list_values %}
                     <li class="list-settings-item">
-                      <label>
-                        <input
-                          type="checkbox"
-                          value="{{choice.value}}"
-                          style="width:auto;height:auto;"
-                          {% if choice.value in field.value %}checked="checked"{% endif %}
-                        >
+                      <input
+                        id="xb-field-edit-{{field.name}}-{{forloop.counter}}"
+                        type="checkbox"
+                        value="{{choice.value}}"
+                        style="width:auto;min-width:auto;height:auto;float:left;margin-top:3px;"
+                        {% if choice.value in field.value %}checked="checked"{% endif %}
+                      >
+                      <label for="xb-field-edit-{{field.name}}-{{forloop.counter}}" style="display:block;margin-left:1.1em;">
                         {{choice.display_name}}
                       </label>
                     </li>


### PR DESCRIPTION
This is a very minor change to improve the appearance of checkboxes and `list_values_provider` display_names in the studio editor.

Goes from:
![screen shot 2015-03-30 at 8 32 25 pm](https://cloud.githubusercontent.com/assets/945577/6911900/eaed076a-d71b-11e4-88ff-4e9294e161e0.png)


To:
![screen shot 2015-03-30 at 8 31 28 pm](https://cloud.githubusercontent.com/assets/945577/6911891/c941b52a-d71b-11e4-8a93-e9ade79407ea.png)

Note: The screenshots are old - this PR now only affects the layout of the checkboxes - it does not affect whether or not HTML is parsed. That can be controlled using Django's `mark_safe`