### PR TITLE
Tell TinyMCE not to change our URLs!

### DIFF
--- a/xblockutils/public/studio_edit.js
+++ b/xblockutils/public/studio_edit.js
@@ -52,6 +52,7 @@ function StudioEditableXBlockMixin(runtime, element) {
                 height: '200px',
                 formats: { code: { inline: 'code' } },
                 codemirror: { path: "" + baseUrl + "/js/vendor" },
+                convert_urls: false,
                 plugins: "link codemirror",
                 menubar: false,
                 statusbar: false,


### PR DESCRIPTION
JIRA: SOL-787

If the "HTML" editor is used on an XBlock field with StudioEditableMixin, TinyMCE will "helpfully" rewrite URLs like "/jump_to_id/0f71244e743243eab10d316a7911555a" to "../../../../../jump_to_id/0f71244e743243eab10d316a7911555a", which breaks some of the things.

Luckily, the fix is straightforward.