### PR TITLE
Set the base URL of TinyMCE before initialising it.

### DIFF
--- a/xblockutils/public/studio_edit.js
+++ b/xblockutils/public/studio_edit.js
@@ -46,6 +46,7 @@ function StudioEditableXBlockMixin(runtime, element) {
         if (type == 'html' && tinyMceAvailable) {
             if ($field.tinymce())
                 $field.tinymce().remove(); // Stale instance from a previous dialog. Delete it to avoid interference.
+            tinyMCE.baseURL = baseUrl + "/js/vendor/tinymce/js/tinymce";
             $field.tinymce({
                 theme: 'modern',
                 skin: 'studio-tmce4',


### PR DESCRIPTION
**Description**

This change fixes the raw HTML editor in production environments.  In the old version, using the "HTML" button on the WYSIWYG HTML editor results in a modal popup showing a 404.  With this fix applied, the raw HTML editor works correctly.

For testing, add an XBlock that uses the HTML editor to a unit in [Studio](http://sandbox2.opencraft.com:18010/), click "EDIT" on that XBlock and then the "HTML" button in the top right corner of the HTML editor.  An example for an XBlock using this editor is a "Message" inside a "Mentoring Question".

To reproduce the original problem, go to [this test unit on stage]( https://studio.stage.edx.org/container/block-v1:SvenX+4711+2015+type@vertical+block@1d1dd09bde2c4561af022cc6a7c241b4), click "EDIT" on the first component, scroll to the bottom an click the "HTML" button on one of the HTML editors.
- - -
**Partner information** hosted on edx.org (Davidson)
**JIRA Story** N/A
**Confluence / Product Asset** N/A
**Sandbox URL** http://sandbox2.opencraft.com:18010/, e.g. the [second component in this unit](http://sandbox2.opencraft.com:18010/container/block-v1:OpenCraft+PB101+150408+type@problem-builder+block@7e76bd9836ee47bb94dff085b9ae9175)
**Dependencies** N/A
**PR Author(s) Notes / To-Do** N/A
- - -
**Screenshots** 
Broken editor:
![image](https://cloud.githubusercontent.com/assets/249196/8079517/4f6233b0-0f65-11e5-9db6-dc5f2021c42f.png)
Fixed editor:
![image](https://cloud.githubusercontent.com/assets/249196/8079537/7896953c-0f65-11e5-8120-5f58649ff804.png)
- - -
**Reviewers**
Code: Jonathan Piacenti,(TBD)