### PR TITLE
Fix minor bug with preview_view feature.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ before_install:
     - "export DISPLAY=:99"
     - "sh -e /etc/init.d/xvfb start"
 install:
-    - "pip install -e git://github.com/edx/xblock-sdk.git#egg=xblock-sdk"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements.txt"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/test-requirements.txt"
+    - "pip install -e git://github.com/edx/xblock-sdk.git@22c1b2f173919bef22f2d9d9295ec5396d02dffd#egg=xblock-sdk"
+    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
+    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
     - "pip install -r requirements.txt"
     - "pip install -r test_requirements.txt"
+    - "mkdir var"
 script:
     - pep8 xblockutils --max-line-length=120
     - pylint xblockutils

--- a/xblockutils/studio_editable.py
+++ b/xblockutils/studio_editable.py
@@ -468,8 +468,7 @@ class StudioContainerWithNestedXBlocksMixin(StudioContainerXBlockMixin):
         fragment = Fragment()
         for child_id in self.children:
             child = self.runtime.get_block(child_id)
-            view_to_render = 'preview_view' if hasattr(child, 'preview_view') else 'student_view'
-            child_fragment = self._render_child_fragment(child, context, view_to_render)
+            child_fragment = self._render_child_fragment(child, context, 'preview_view')
             fragment.add_frag_resources(child_fragment)
             children_contents.append(child_fragment.content)
 


### PR DESCRIPTION
This fixes a minor bug with the `preview_view` feature, where it was bypassing the code in `_render_child_fragment` that has special-case code for compatibility with the `html` block in edx-platform.

**Before** - unwanted Studio widgets are showing up in the XBlock preview:
![screen shot 2015-10-31 at 11 52 19 pm](https://cloud.githubusercontent.com/assets/945577/10867642/7dabddda-802a-11e5-9a75-6c46024dbcdb.png)

**After**:
![screen shot 2015-10-31 at 11 53 45 pm](https://cloud.githubusercontent.com/assets/945577/10867658/a968d158-802a-11e5-87a3-2b3c45ca0863.png)
