### PR TITLE
Sprint Zug PHX-201 Allow HTML to be included in XBlock Field help strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-utils',
-    version='0.1a0',
+    version='v1.0.0',
     description='Various utilities for XBlocks',
     packages=[
         'xblockutils',

--- a/tests/integration/test_studio_editable.py
+++ b/tests/integration/test_studio_editable.py
@@ -2,6 +2,7 @@ import datetime
 import textwrap
 import mock
 import pytz
+from selenium.common.exceptions import NoSuchElementException
 from xblock.core import XBlock
 from xblock.fields import Boolean, Dict, Float, Integer, List, String, DateTime
 from xblock.fragment import Fragment
@@ -274,13 +275,17 @@ class FancyXBlock(StudioEditableXBlockMixin, XBlock):
     string_multiline = String(display_name="Multiline", multiline_editor=True, allow_reset=False)
     string_multiline_reset = String(display_name="Multiline", multiline_editor=True)
     string_html = String(display_name="Multiline", multiline_editor='html', allow_reset=False)
+    string_with_help = String(
+        display_name="String Field with Help Text",
+        help="Learn more about <a class='field_help_link' href='https://en.wikipedia.org/wiki/Color'>colors</a>."
+    )
     # Note: The HTML editor won't work in Workbench because it depends on Studio's TinyMCE
 
     editable_fields = (
         'bool_normal', 'dict_normal', 'float_normal', 'float_values', 'int_normal', 'int_ranged', 'int_dynamic',
         'int_values', 'list_normal', 'list_intdefs', 'list_strdefs', 'list_set_ints', 'list_set_strings',
         'string_normal', 'string_values', 'string_values_provider', 'string_named', 'string_dynamic',
-        'string_multiline', 'string_multiline_reset', 'string_html',
+        'string_multiline', 'string_multiline_reset', 'string_html', 'string_with_help'
     )
 
     def student_view(self, context):
@@ -338,6 +343,7 @@ class TestFancyXBlock_StudioView(StudioEditableBaseTest):
         block.string_multiline = "why\nhello\there"
         block.string_multiline_reset = "indubitably"
         block.string_html = "<strong>Testing!</strong>"
+        block.string_with_help = "Red"
         block.save()
 
         orig_values = {field_name: getattr(block, field_name) for field_name in FancyXBlock.editable_fields}
@@ -354,6 +360,17 @@ class TestFancyXBlock_StudioView(StudioEditableBaseTest):
                 "{} should be unchanged".format(field_name)
             )
             self.assertTrue(block.fields[field_name].is_set_on(block))
+
+    @XBlock.register_temp_plugin(FancyXBlock, "fancy")
+    def test_html_in_help(self):
+        """
+        If we include HTML in the help text for a field, the HTML should be displayed in the rendered page
+        """
+        block = self.set_up_root_block()
+        try:
+            self.browser.find_element_by_class_name('field_help_link')
+        except NoSuchElementException:
+            self.fail("HTML anchor tag missing from field help text")
 
 
 class FancyBlockShim(object):

--- a/tests/unit/data/simple_django_template.txt
+++ b/tests/unit/data/simple_django_template.txt
@@ -1,4 +1,4 @@
-This is a simple django template example.
+This is a simple template example.
 
 This template can make use of the following context variables:
 Name: {{name}}

--- a/tests/unit/data/simple_mako_template.txt
+++ b/tests/unit/data/simple_mako_template.txt
@@ -1,0 +1,14 @@
+This is a simple template example.
+
+This template can make use of the following context variables:
+Name: ${name}
+List: ${items}
+
+It can also do some fancy things with them:
+Default value if name is empty: ${ name or "Default Name"}
+Length of the list: ${len(items)}
+Items of the list:\
+% for item in items:
+ ${item}\
+% endfor
+

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -20,11 +20,13 @@
 
 import unittest
 
+from mock import patch, DEFAULT
+
 from xblockutils.resources import ResourceLoader
 
 
 expected_string = u"""\
-This is a simple django template example.
+This is a simple template example.
 
 This template can make use of the following context variables:
 Name: {{name}}
@@ -44,7 +46,7 @@ example_context = {
 
 
 expected_filled_template = u"""\
-This is a simple django template example.
+This is a simple template example.
 
 This template can make use of the following context variables:
 Name: This is a fine name
@@ -98,9 +100,21 @@ class TestResourceLoader(unittest.TestCase):
         s = ResourceLoader("tests.unit.data").load_unicode("simple_django_template.txt")
         self.assertEquals(s, expected_string)
 
-    def test_render_template(self):
+    def test_render_django_template(self):
+        loader = ResourceLoader(__name__)
+        s = loader.render_django_template("data/simple_django_template.txt", example_context)
+        self.assertEquals(s, expected_filled_template)
+
+    def test_render_mako_template(self):
+        loader = ResourceLoader(__name__)
+        s = loader.render_mako_template("data/simple_mako_template.txt", example_context)
+        self.assertEquals(s, expected_filled_template)
+
+    @patch('warnings.warn', DEFAULT)
+    def test_render_template_deprecated(self, mock_warn):
         loader = ResourceLoader(__name__)
         s = loader.render_template("data/simple_django_template.txt", example_context)
+        self.assertTrue(mock_warn.called)
         self.assertEquals(s, expected_filled_template)
 
     def test_render_js_template(self):

--- a/xblockutils/resources.py
+++ b/xblockutils/resources.py
@@ -24,9 +24,14 @@ Helper class (ResourceLoader) for loading resources used by an XBlock
 
 import os
 import sys
+import warnings
 
 import pkg_resources
+
 from django.template import Context, Template
+
+from mako.template import Template as MakoTemplate
+from mako.lookup import TemplateLookup as MakoTemplateLookup
 
 
 class ResourceLoader(object):
@@ -41,14 +46,33 @@ class ResourceLoader(object):
         resource_content = pkg_resources.resource_string(self.module_name, resource_path)
         return unicode(resource_content)
 
-    def render_template(self, template_path, context=None):
+    def render_django_template(self, template_path, context=None):
         """
-        Evaluate a template by resource path, applying the provided context
+        Evaluate a django template by resource path, applying the provided context
         """
         context = context or {}
         template_str = self.load_unicode(template_path)
         template = Template(template_str)
         return template.render(Context(context))
+
+    def render_mako_template(self, template_path, context=None):
+        """
+        Evaluate a mako template by resource path, applying the provided context
+        """
+        context = context or {}
+        template_str = self.load_unicode(template_path)
+        lookup = MakoTemplateLookup(directories=[pkg_resources.resource_filename(self.module_name, '')])
+        template = MakoTemplate(template_str, lookup=lookup)
+        return template.render(**context)
+
+    def render_template(self, template_path, context=None):
+        """
+        This function has been deprecated. It calls render_django_template to support backwards compatibility.
+        """
+        warnings.warn(
+            "ResourceLoader.render_template has been deprecated in favor of ResourceLoader.render_django_template"
+        )
+        return self.render_django_template(template_path, context)
 
     def render_js_template(self, template_path, element_id, context=None):
         """

--- a/xblockutils/templates/studio_edit.html
+++ b/xblockutils/templates/studio_edit.html
@@ -93,7 +93,7 @@
             {% endif %}
           </div>
           {% if field.help %}
-            <span class="tip setting-help"> {{ field.help }} </span>
+            <span class="tip setting-help"> {{ field.help|safe }} </span>
           {% endif %}
         </li>
       {% endfor %}


### PR DESCRIPTION
I am migrating the LTI component from https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/lti_module.py to a new XBlock repo and I would like to use this package to render the studio edit view of the XBlock.

The existing xmodule implementation includes some HTML links to documentation in the help attribute of Field definitions. This change will allow those HTML links to be displayed when the studio edit view is rendered.

The existing xmodule implementation of the LTI component also uses Mako templates. I have added `ResourceLoader.render_mako_template` in order to support this. I have also added `ResourceLoader.render_django_template` and deprecated `ResourceLoader.render_template` in order to keep the API naming consistent.