### PR TITLE
Support loading resources that contain non-ASCII characters

### DIFF
--- a/tests/unit/data/simple_django_template.txt
+++ b/tests/unit/data/simple_django_template.txt
@@ -8,3 +8,7 @@ It can also do some fancy things with them:
 Default value if name is empty: {{name|default:"Default Name"}}
 Length of the list: {{items|length}}
 Items of the list:{% for item in items %} {{item}}{% endfor %}
+
+Although it is simple, it can also contain non-ASCII characters:
+
+Thé Fütüré øf Ønlïné Édüçätïøn Ⱡσяєм ι# Før änýøné, änýwhéré, änýtïmé Ⱡσяєм #

--- a/tests/unit/data/simple_mako_template.txt
+++ b/tests/unit/data/simple_mako_template.txt
@@ -12,3 +12,7 @@ Items of the list:\
  ${item}\
 % endfor
 
+
+Although it is simple, it can also contain non-ASCII characters:
+
+Thé Fütüré øf Ønlïné Édüçätïøn Ⱡσяєм ι# Før änýøné, änýwhéré, änýtïmé Ⱡσяєм #

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -36,6 +36,10 @@ It can also do some fancy things with them:
 Default value if name is empty: {{name|default:"Default Name"}}
 Length of the list: {{items|length}}
 Items of the list:{% for item in items %} {{item}}{% endfor %}
+
+Although it is simple, it can also contain non-ASCII characters:
+
+Thé Fütüré øf Ønlïné Édüçätïøn Ⱡσяєм ι# Før änýøné, änýwhéré, änýtïmé Ⱡσяєм #
 """
 
 
@@ -56,6 +60,10 @@ It can also do some fancy things with them:
 Default value if name is empty: This is a fine name
 Length of the list: 7
 Items of the list: 1 2 3 4 a b c
+
+Although it is simple, it can also contain non-ASCII characters:
+
+Thé Fütüré øf Ønlïné Édüçätïøn Ⱡσяєм ι# Før änýøné, änýwhéré, änýtïmé Ⱡσяєм #
 """
 
 example_id = "example-unique-id"

--- a/xblockutils/resources.py
+++ b/xblockutils/resources.py
@@ -44,7 +44,7 @@ class ResourceLoader(object):
         Gets the content of a resource
         """
         resource_content = pkg_resources.resource_string(self.module_name, resource_path)
-        return unicode(resource_content)
+        return unicode(resource_content, 'utf-8')
 
     def render_django_template(self, template_path, context=None):
         """


### PR DESCRIPTION
Using `ResourceLoader.load_unicode` to load files containing non-ASCII characters results in errors such as:

    Error: 'ascii' codec can't decode byte 0xc2 in position 5557: ordinal not in range(128)

This PR fixes that by making `load_unicode` explicitly specify the encoding to use (`utf-8`) when calling `unicode` on a loaded resource.
