### PR TITLE
Fix translation of field names and help text in studio_view

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 # XBlock
 # This is not in/from PyPi, since it moves fast
 
--e git+https://github.com/edx/XBlock.git@tag-master-2015-05-22#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@xblock-0.4.10#egg=XBlock==0.4.10

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-utils',
-    version='1.0.2',
+    version='1.0.3',
     description='Various utilities for XBlocks',
     packages=[
         'xblockutils',

--- a/xblockutils/studio_editable.py
+++ b/xblockutils/studio_editable.py
@@ -13,7 +13,6 @@ StudioEditableXBlockMixin to your XBlock.
 import json
 import logging
 
-from django.utils.translation import ugettext
 from xblock.core import XBlock
 from xblock.fields import Scope, JSONField, List, Integer, Float, Boolean, String, DateTime
 from xblock.exceptions import JsonHandlerError, NoSuchViewError
@@ -107,6 +106,14 @@ class StudioEditableXBlockMixin(object):
             (DateTime, 'datepicker'),
             (JSONField, 'generic'),  # This is last so as a last resort we display a text field w/ the JSON string
         )
+        if self.service_declaration("i18n"):
+            ugettext = self.ugettext
+        else:
+
+            def ugettext(text):
+                """ Dummy ugettext method that doesn't do anything """
+                return text
+
         info = {
             'name': field_name,
             'display_name': ugettext(field.display_name) if field.display_name else "",


### PR DESCRIPTION
This fixes the studio_view of `StudioEditableXBlockMixin` so that it can correctly load translations from `text.po` files included with each XBlock. The current version only works if the translation happens to be in edx-platform's django.po; it wasn't searching the `text.po` files of installed XBlocks.

**Project/Partner**: This came up in the context of planning my XBlock tutorial for the edX conference, so this is just a community OSPR contribution from OpenCraft.

**Merge deadline**: No particular deadline.

**Affects**: xblock-lti-consumer, Problem Builder, Grammarian, possibly others

**Before** (Note that coincidentally the field names in this screenshot were in edx-platform's po file, but the help text is not being translated):
![screen shot 2016-06-08 at 5 14 54 pm](https://cloud.githubusercontent.com/assets/945577/15915943/9b7ddf86-2da2-11e6-9353-43022c5f6816.png)

**After**:
![screen shot 2016-06-08 at 5 15 02 pm](https://cloud.githubusercontent.com/assets/945577/15915945/a0b7d6a0-2da2-11e6-97b0-24ea91dafe7a.png)

**Test Instructions**:

1. On devstack, as `edxapp`, install the demo XBlock from the screenshot: `pip install git+https://github.com/open-craft/xblock-grammarian.git@34df60eb9a96f745da6a390454b1a1548cf5c5f4#egg=xblock-grammarian`
2. Compile the dummy .po to .mo: `cd $(python -c "import grammarian, os; print os.path.dirname(grammarian.__file__) + '/translations/eo/LC_MESSAGES'") && msgfmt text.po -o text.mo && cd -`
3. (Re)start Studio
4. Import https://github.com/open-craft/demo-courses/tarball/grammarian into Studio
5. Navigate into that course to the XBlock in question
6. Go to `?preview-lang=eo` to enable the dummy translation
7. Click "Edit" to edit the Grammarian XBlock. Confirm the field names and help text are shown with dummy translation accents.

**Notes**:
Includes a version bump to 1.0.3 and bumps the required version of `XBlock` to one that includes i18n functionality.
