### PR TITLE
Fix bug: Single-instance buttons do nothing after disabled

### DIFF
--- a/xblockutils/public/studio_container.js
+++ b/xblockutils/public/studio_container.js
@@ -1,20 +1,25 @@
 function StudioContainerXBlockWithNestedXBlocksMixin(runtime, element) {
     var $buttons = $(".add-xblock-component-button", element),
+        $addComponent = $('.add-xblock-component', element),
         $element = $(element);
 
     function isSingleInstance($button) {
         return $button.data('single-instance');
     }
 
-    $buttons.click(function(ev) {
-        var $this = $(this);
-        if ($this.is('.disabled')) {
+    // We use delegated events here, i.e., not binding a click event listener
+    // directly to $buttons, because we want to make sure any other click event
+    // listeners of the button are called first before we disable the button.
+    // Ref: OSPR-1393
+    $addComponent.on('click', '.add-xblock-component-button', function(ev) {
+        var $button = $(ev.currentTarget);
+        if ($button.is('.disabled')) {
             ev.preventDefault();
             ev.stopPropagation();
         } else {
-            if (isSingleInstance($this)) {
-                $this.addClass('disabled');
-                $this.attr('disabled', 'disabled');
+            if (isSingleInstance($button)) {
+                $button.addClass('disabled');
+                $button.attr('disabled', 'disabled');
             }
         }
     });


### PR DESCRIPTION
This is to fix open-craft/problem-builder#118, where a button marked with 'single-instance' data got disabled first, hence its click event handler at edx-platform is not called.

This patch solves this issue by correcting the calling order, so that we invoke the click event handler at edx-platform first; then we disable the button.

cc: @antoviaque @bradenmacdonald 