### PR TITLE
Remove block_settings_key declaration from XBlockWithSettingsMixin

### DIFF
--- a/xblockutils/settings.py
+++ b/xblockutils/settings.py
@@ -17,8 +17,9 @@ class XBlockWithSettingsMixin(object):
         block_settings_key: string - XBlock settings is essentially a dictionary-like object (key-value storage).
                                      Each XBlock must provide a key to look its settings up in this storage.
                                      Settings Service uses `block_settings_key` attribute to get the XBlock settings key
+                                     If the `block_settings_key` is not provided the XBlock class name will be used.
     """
-    block_settings_key = None
+    # block_settings_key = "XBlockName"  # (Optional)
 
     def get_xblock_settings(self, default=None):
         """


### PR DESCRIPTION
When I tried getting the XBlock settings from `cms.env.json` it would fail because the bucket would use the [block_settings_key](https://github.com/edx/xblock-utils/blob/master/xblockutils/settings.py#L21) instead of defaulting to the [XBlock class name](https://github.com/edx/edx-platform/blob/6d2468d0dcf782a7561ecc61946146d6fae2762f/common/lib/xmodule/xmodule/services.py#L61).