### PR TITLE
[MCKIN-7023] Ensures that default template tags are loaded for Django 1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-utils',
-    version='1.1.0',
+    version='1.1.1',
     description='Various utilities for XBlocks',
     packages=[
         'xblockutils',

--- a/tests/unit/data/l10n_django_template.txt
+++ b/tests/unit/data/l10n_django_template.txt
@@ -1,0 +1,3 @@
+{% load l10n %}
+{{ 1000|localize }}
+{{ 1000|unlocalize }}

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -90,6 +90,12 @@ mUlTi_LiNe TrAnSlAtIoN: This is a fine name
 
 """
 
+expected_localized_template = u"""\
+
+1000
+1000
+"""
+
 example_id = "example-unique-id"
 
 expected_filled_js_template = u"""\
@@ -166,6 +172,14 @@ class TestResourceLoader(unittest.TestCase):
         # Test that the language changes were reverted
         s = loader.render_django_template("data/trans_django_template.txt", example_context)
         self.assertEquals(s, expected_not_translated_template)
+
+    def test_render_django_template_localized(self):
+        # Test that default template tags like l10n are loaded
+        loader = ResourceLoader(__name__)
+        s = loader.render_django_template("data/l10n_django_template.txt",
+                                          context=example_context,
+                                          i18n_service=MockI18nService())
+        self.assertEquals(s, expected_localized_template)
 
     def test_render_mako_template(self):
         loader = ResourceLoader(__name__)

--- a/xblockutils/resources.py
+++ b/xblockutils/resources.py
@@ -68,7 +68,11 @@ class ResourceLoader(object):
             engine = Engine()
         else:
             # Django>1.8 Engine can load the extra templatetag libraries itself
-            engine = Engine(libraries=libraries)
+            # but we have to override the default installed libraries.
+            from django.template.backends.django import get_installed_libraries
+            installed_libraries = get_installed_libraries()
+            installed_libraries.update(libraries)
+            engine = Engine(libraries=installed_libraries)
 
         template_str = self.load_unicode(template_path)
         template = Template(template_str, engine=engine)


### PR DESCRIPTION
Fixes bug related to the Django 1.11 upgrade and support for translations in XBlock templates added by https://github.com/edx/xblock-utils/pull/48.

Ensures that the standard Django templatetag libraries continue to work in XBlock templates (e.g., [DnDv2](https://github.com/edx-solutions/xblock-drag-and-drop-v2/blob/master/drag_and_drop_v2/templates/html/drag_and_drop_edit.html#L2) uses `l10n`).

**JIRA tickets**: [MCKIN-7023](https://edx-wiki.atlassian.net/browse/MCKIN-7023), OSPR 

**Discussions**: [WL-230](https://openedx.atlassian.net/browse/WL-230), [YONK-879](https://openedx.atlassian.net/browse/YONK-879?focusedCommentId=307771&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-307771)

**Screenshots**: 

**Before** 
Before this fix and since edx-platform was upgraded to Django 1.11, attempts to edit the DnDv2 XBlock in Studio resulted in this error:
![before](https://user-images.githubusercontent.com/7556571/39793249-c885b98c-5383-11e8-937b-7b09f931c39b.png)

**After** this change, DnDv2 XBlock can be edited as expected:
![after](https://user-images.githubusercontent.com/7556571/39793343-425c5996-5384-11e8-9246-f844b7aabc40.png)

**Sandbox URL**: (provisioning)

* LMS: https://pr17670.sandbox.opencraft.hosting/
* Studio: https://studio-pr17670.sandbox.opencraft.hosting/

**Merge deadline**: ASAP

**Testing instructions**:

1. In Studio, create a course and add a Drag and Drop problem (e.g. [sandbox Drag and Drop](https://studio-pr17670.sandbox.opencraft.hosting/container/block-v1:OpenCraft+DnDv2+2018_1+type@vertical+block@a2b13b1603724df192e1c43dd3f1d70d?action=new#))
1. Edit the DnDv2 XBlock.
   Note that this works as expected.

**Reviewers**
- [ ] @mtyaka 
- [ ] edx-solutions reviewer[s] TBD

CC @macdiesel 