### PR TITLE
Run Travis on tagged commits for PyPI deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ script:
     - tox -e $TOX_ENV
 notifications:
   email: false
-branches:
-    only:
-        - master
 deploy:
   provider: pypi
   user: edx


### PR DESCRIPTION
This restriction prevented the previous tagged commit from being deployed to PyPI.  Most of our other library repos don't use this restriction, so removing to fix deployments.