### PR TITLE
Bump minor version to package py3 updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def is_requirement(line):
 
 
 README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
-VERSION = '1.2.0'
+VERSION = '1.2.1'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
I'm working on py3 compatibility for some of our (Stanford's) XBlocks.
Currently, tests fail as the recent py3 compatibility changes,
while merged to master, have not yet been published to PyPI.

I'd like to use this opportunity to bump the version and update the PyPI
distribution.