### PR TITLE
[MCKIN-8266] <span> and <i> Tags are being removed fixed in tinymce.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def is_requirement(line):
 
 
 README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
-VERSION = '1.2.1'
+VERSION = '1.2.2'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")

--- a/xblockutils/public/studio_edit.js
+++ b/xblockutils/public/studio_edit.js
@@ -63,6 +63,7 @@ function StudioEditableXBlockMixin(runtime, element) {
                 toolbar_items_size: 'small',
                 toolbar: "formatselect | styleselect | bold italic underline forecolor wrapAsCode | bullist numlist outdent indent blockquote | link unlink | code",
                 resize: "both",
+                extended_valid_elements : 'i[class],span[class]',
                 setup : function(ed) {
                     ed.on('change', fieldChanged);
                 }


### PR DESCRIPTION
In TinyMCE's `html` editor eliminates `span` and `i` tags on saving that. We are not able to use those tags, therefore, this PR extends valid tags and put them in the list. 