### PR TITLE
Pinned importlib-metadata==1.7.0 for python35

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,3 +12,6 @@
 # suite of xblock-sdk in this package
 bok_choy==0.7.1
 selenium==3.4.1
+
+# importlib-metadata>1.7.0 causing conflicts in make upgrade on python35
+importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,10 +7,10 @@
 appdirs==1.4.4            # via -r requirements/test.txt, -r requirements/travis.txt, fs, virtualenv
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.2.0             # via -r requirements/test.txt, pytest
-bleach==3.2.0             # via -r requirements/test.txt, readme-renderer
+bleach==3.2.1             # via -r requirements/test.txt, readme-renderer
 bok_choy==0.7.1           # via -r requirements/test.txt
-boto3==1.15.0             # via -r requirements/test.txt, fs-s3fs
-botocore==1.18.0          # via -r requirements/test.txt, boto3, s3transfer
+boto3==1.15.5             # via -r requirements/test.txt, fs-s3fs
+botocore==1.18.5          # via -r requirements/test.txt, boto3, s3transfer
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, edx-lint, pip-tools
 ddt==1.4.1                # via -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,10 +7,10 @@
 appdirs==1.4.4            # via -r requirements/base.txt, fs
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==20.2.0             # via pytest
-bleach==3.2.0             # via readme-renderer
+bleach==3.2.1             # via readme-renderer
 bok_choy==0.7.1           # via -c requirements/constraints.txt, -r requirements/test.in
-boto3==1.15.0             # via fs-s3fs
-botocore==1.18.0          # via boto3, s3transfer
+boto3==1.15.5             # via fs-s3fs
+botocore==1.18.5          # via boto3, s3transfer
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 ddt==1.4.1                # via -r requirements/test.in
@@ -19,7 +19,7 @@ docutils==0.16            # via readme-renderer
 edx-lint==1.5.2           # via -r requirements/test.in
 fs-s3fs==1.1.1            # via django-pyfs
 fs==2.4.11                # via -r requirements/base.txt, django-pyfs, fs-s3fs, xblock
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 jmespath==0.10.0          # via boto3, botocore

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,7 +7,7 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox


### PR DESCRIPTION
- `importlib-metadata>1.7.0` is causing conflicts in `make upgrade` on `python35`, hence pinned it to `1.7.0`.