### PR TITLE
Unpin importlib-metadata constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,6 +12,3 @@
 # suite of xblock-sdk in this package
 bok_choy==0.7.1
 selenium==3.4.1
-
-# importlib-metadata>1.7.0 causing conflicts in make upgrade on python35
-importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,8 +9,8 @@ astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.2.0             # via -r requirements/test.txt, pytest
 bleach==3.2.1             # via -r requirements/test.txt, readme-renderer
 bok_choy==0.7.1           # via -r requirements/test.txt
-boto3==1.15.15            # via -r requirements/test.txt, fs-s3fs
-botocore==1.18.15         # via -r requirements/test.txt, boto3, s3transfer
+boto3==1.15.16            # via -r requirements/test.txt, fs-s3fs
+botocore==1.18.16         # via -r requirements/test.txt, boto3, s3transfer
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, edx-lint, pip-tools
 ddt==1.4.1                # via -r requirements/test.txt
@@ -22,7 +22,7 @@ edx-lint==1.5.2           # via -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 fs-s3fs==1.1.1            # via -r requirements/test.txt, django-pyfs
 fs==2.4.11                # via -r requirements/test.txt, django-pyfs, fs-s3fs, xblock
-importlib-metadata==1.7.0  # via -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.0.0  # via -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
@@ -55,7 +55,7 @@ pytest==6.1.1             # via -r requirements/test.txt, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, botocore, xblock
 pytz==2020.1              # via -r requirements/test.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/test.txt, xblock
-readme-renderer==26.0     # via -r requirements/test.txt
+readme-renderer==27.0     # via -r requirements/test.txt
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 selenium==3.4.1           # via -r requirements/test.txt, bok-choy, needle
 simplejson==3.17.2        # via -r requirements/test.txt
@@ -63,7 +63,7 @@ six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/t
 sqlparse==0.4.1           # via -r requirements/test.txt, django
 toml==0.10.1              # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
-tox==3.20.0               # via -r requirements/travis.txt, tox-battery
+tox==3.20.1               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 typing==3.7.4.3           # via -r requirements/test.txt, fs
 urllib3==1.25.10          # via -r requirements/test.txt, botocore

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,8 +9,8 @@ astroid==2.3.3            # via pylint, pylint-celery
 attrs==20.2.0             # via pytest
 bleach==3.2.1             # via readme-renderer
 bok_choy==0.7.1           # via -c requirements/constraints.txt, -r requirements/test.in
-boto3==1.15.15            # via fs-s3fs
-botocore==1.18.15         # via boto3, s3transfer
+boto3==1.15.16            # via fs-s3fs
+botocore==1.18.16         # via boto3, s3transfer
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 ddt==1.4.1                # via -r requirements/test.in
@@ -19,7 +19,7 @@ docutils==0.16            # via readme-renderer
 edx-lint==1.5.2           # via -r requirements/test.in
 fs-s3fs==1.1.1            # via django-pyfs
 fs==2.4.11                # via -r requirements/base.txt, django-pyfs, fs-s3fs, xblock
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 jmespath==0.10.0          # via boto3, botocore
@@ -50,7 +50,7 @@ pytest==6.1.1             # via pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, xblock
 pytz==2020.1              # via -r requirements/base.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/base.txt, xblock
-readme-renderer==26.0     # via -r requirements/test.in
+readme-renderer==27.0     # via -r requirements/test.in
 s3transfer==0.3.3         # via boto3
 selenium==3.4.1           # via -c requirements/constraints.txt, -r requirements/test.in, bok-choy, needle
 simplejson==3.17.2        # via -r requirements/base.txt

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,7 +7,7 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
+importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -16,6 +16,6 @@ pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.20.0               # via -r requirements/travis.in, tox-battery
+tox==3.20.1               # via -r requirements/travis.in, tox-battery
 virtualenv==20.0.33       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
- `importlib-metadata>=2.0.0` was causing conflicts in running `make upgrade` with `python3.5`.
- Unpinned `importlib-metadata` constraint after fixing the issue in https://github.com/pypa/virtualenv/pull/1953 and https://github.com/tox-dev/tox/pull/1682.